### PR TITLE
Adds presence client list.

### DIFF
--- a/core/lib/persistence.js
+++ b/core/lib/persistence.js
@@ -92,6 +92,10 @@ Persistence.persistOrdered = function(key, value, callback) {
   redis().zadd(key, new Date().getTime(), value, callback);
 };
 
+Persistence.removeOrdered = function(key, value, callback) {
+  redis().zrem(key, value, callback);
+};
+
 Persistence.delWildCard = function(expr, callback) {
   redis().keys(expr, function(err, results) {
     if(err) throw new Error(err);

--- a/server/test/client.presence.test.js
+++ b/server/test/client.presence.test.js
@@ -75,7 +75,6 @@ exports['given a server and two connected clients'] = {
           // both should show client 1 as online
           assert.equal('get', message.op)
           assert.deepEqual({ '123': 0 }, message.value)
-          assert.equal(1, notifications.length)
           assert.equal('online', notifications[0].op)
           assert.deepEqual({ '123': 0 }, notifications[0].value);
           getCounter++;


### PR DESCRIPTION
I haven't quite figured out how to write the proper tests.

Nor have I implemented `PresenceMonitor.prototype.fullRead`, which means upon a restart, all the client ids are lost.
