### PR TITLE
Spotted what looks like a few typos in the documentation...

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,11 +227,11 @@ radar_client info {&quot;op&quot;:&quot;sync&quot;,&quot;to&quot;:&quot;message:
 <pre>var Type = require(&#39;radar&#39;).core.Type;
 
 Type.register(&#39;chatMessage&#39;, {
-    expr: new RegExp(&#39;^message:/.+/chat/(.+){{content}}#39;),
+    expr: new RegExp(&#39;^message:/.+/chat/.+$&#39;),
     type: &#39;message&#39;,
     policy: { cache: true, maxCount: 300 }
 });</pre>
-<p>Here, we&#39;re specifying a new type of channel - it is applied to chanlles that match the regular expression. The <code>policy</code> key defines that the data should be cached - which is what we want so that messages are kept around; <code>maxCount</code> says that we will keep up to 300 messages (see the server docs for the other options).</p>
+<p>Here, we&#39;re specifying a new type of channel - it is applied to channels that match the regular expression. The <code>policy</code> key defines that the data should be cached - which is what we want so that messages are kept around; <code>maxCount</code> says that we will keep up to 300 messages (see the server docs for the other options).</p>
 <p>Once you do this and restart the server, you&#39;ll start to see that previously published messages are now synchronized back to your client. This makes it a lot easier to implement a chat with history. Since the persistence policy is determined via a RegExp, you can set different policies for different use cases.</p>
 <h3>8. Creating a chat - presence resource</h3>
 <p>OK, so we can now have two users join a chat channel, and we have configured the caching policy to keep old messages around.</p>

--- a/server.html
+++ b/server.html
@@ -107,7 +107,7 @@ Radar.attach(server, configuration);</pre>
 <p>Each policy has a name, and a set of properties. <code>my_types.js</code> could contain something like this:</p>
 <pre>module.exports = {
   chat_messages: {
-    expr: new RegExp(&#39;^message:/.+/chat/.+{{content}}#39;),
+    expr: new RegExp(&#39;^message:/.+/chat/.+$&#39;),
     type: &#39;message&#39;,
     policy: { cache: true },
     auth: function(message) {


### PR DESCRIPTION
- fixed code samples for initializing type filters
- corrected a few typos
