### PR TITLE
Issue #32: Allow configuration to select redis db

### DIFF
--- a/core/lib/persistence.js
+++ b/core/lib/persistence.js
@@ -19,6 +19,9 @@ function redis() {
     if (configuration.redis_auth) {
       client.auth(configuration.redis_auth);
     }
+    if (configuration.db) {
+      client.select(configuration.db);
+    }
     client.once('ready', function() {
       isConnecting = false;
     });


### PR DESCRIPTION
closes #32 

@zendesk/zendesk-radar 
