### PR TITLE
use port, host not redis_host, redis_port

### DIFF
--- a/core/lib/connection.js
+++ b/core/lib/connection.js
@@ -5,7 +5,7 @@ var redisLib = require('redis'),
     async = require('async');
 
 function redisConnect(config) {
-  var client = redisLib.createClient(config.redis_port, config.redis_host);
+  var client = redisLib.createClient(config.port, config.host);
   if (config.redis_auth) {
     client.auth(config.redis_auth);
   }


### PR DESCRIPTION
@samshull This was causing radar to fallback to localhost:6379.
