### PR TITLE
Do not publish offline to redis on sentry down

### DIFF
--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -42,7 +42,7 @@ PresenceManager.prototype.setup = function() {
   this.sentryListener = function(sentry) {
     store.clientsForSentry(sentry, function(clientId) {
       logging.info('#presence - #sentry down, removing client:', sentry, scope, clientId);
-      manager.disconnectClient(clientId);
+      manager.sentryDownForClient(clientId);
     });
   };
 
@@ -50,6 +50,20 @@ PresenceManager.prototype.setup = function() {
   // since we should not be going down often.
   logging.debug('#presence - add sentry listener', scope);
   this.sentry.on('down', this.sentryListener);
+};
+
+PresenceManager.prototype.sentryDownForClient = function(clientId) {
+  var userId = this.store.userOf(clientId);
+  var userType = this.store.userTypeOf(userId);
+  var message = {
+    userId: userId,
+    userType: userType,
+    clientId: clientId,
+    online: false,
+    explicit: false
+  };
+  this.stampExpiration(message);
+  this.processRedisEntry(message); //directly process
 };
 
 PresenceManager.prototype.destroy = function() {


### PR DESCRIPTION
Since every server who detects sentry down will publish this
in close succession, there are a lot of wasteful redis messages due to
sentry down. Instead, we simply treat it like a fake implicit offline
message arrived.
Note: The redis entry will be cleaned up later whenever
someone does a sync or a get. This may cause some client offlines to
arrive on sync from left over sentries.

/cc @zendesk/zendesk-radar
### Steps to merge
- [ ] :+1: of the team
### References
- Jira link: 
### Risks
- Low: Presence issues when sentry goes down.
