### PR TITLE
Replace tight loops in clientsForSentry with chained calls

### DIFF
--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -40,10 +40,21 @@ PresenceManager.prototype.setup = function() {
 
   // save so you removeListener on destroy
   this.sentryListener = function(sentry) {
-    store.clientsForSentry(sentry, function(clientId) {
+    var clientIds = store.clientsForSentry(sentry);
+
+    var chain = function (clientIds) {
+      var clientId = clientIds.pop();
+
+      if (!clientId) return;
+
       logging.info('#presence - #sentry down, removing client:', sentry, scope, clientId);
       manager.sentryDownForClient(clientId);
-    });
+      setImmediate(function () {
+        chain(clientIds);
+      });
+    };
+
+    chain(clientIds);
   };
 
   // Listen to all sentries. This should not be costly,


### PR DESCRIPTION
clientsForSentry has a nested pair of forEach loops which very likely will starve the nodejs event loop when a sentry is deemed to be down.  Replace the loops with a chain of N x M calls that iterate through the userIds/clientIds in the same way.

/cc @zendesk/zendesk-radar
### Steps to merge
- [ ] :+1: of the team
### References
- Jira link: https://zendesk.atlassian.net/browse/RADAR-435
### Risks
- Low: clientsForSentry does not respond to sentry down as expected
