### PR TITLE
set('online') should not subscribe

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+### 0.13.0
+* Set(online) for presence no longer subscribes to the resource.
+    - This is a breaking change if the client assumes this behavior
+
 ### 0.12.5
 * Expose details of sentry down in the listener
 

--- a/core/lib/resources/presence/index.js
+++ b/core/lib/resources/presence/index.js
@@ -101,8 +101,7 @@ Presence.prototype.set = function(client, message) {
   }
 
   if(message.value != 'offline') {
-    // we use subscribe/unsubscribe to trap the "close" event, so subscribe now
-    this.subscribe(client);
+    this._set_online(client);
     this.manager.addClient(client.id, userId, message.type, message.userData, ackCheck);
   } else {
     if(!this.subscribers[client.id]) { //if this is client is not subscribed
@@ -112,6 +111,15 @@ Presence.prototype.set = function(client, message) {
       // remove from local
       this.manager.removeClient(client.id, userId, message.type, ackCheck);
     }
+  }
+};
+
+Presence.prototype._set_online = function(client) {
+  if(!this.subscribers[client.id]) {
+    // we use subscribe/unsubscribe to trap the "close" event, so subscribe now
+    this.subscribe(client);
+    // We are subscribed, but not listening
+    this.subscribers[client.id] = { listening: false }
   }
 };
 
@@ -170,10 +178,11 @@ Presence.prototype.broadcast = function(message, except) {
   var self = this;
   Object.keys(this.subscribers).forEach(function(subscriber) {
     var client = self.parent.server.clients[subscriber];
-    if(client && client.id != except) {
+    if(client && client.id != except && self.subscribers[client.id] === true) {
       client.send(message);
     } else {
-      logging.warn('#client - not sending: ', (client && client.id), message,  except, self.name);
+      logging.warn('#client - not sending: ', (client && client.id), message,  except,
+        'explicit:', (client && client.id && self.subscribers[client.id]), self.name);
     }
   });
 };

--- a/core/lib/resources/presence/index.js
+++ b/core/lib/resources/presence/index.js
@@ -123,6 +123,11 @@ Presence.prototype._set_online = function(client) {
   }
 };
 
+Presence.prototype.subscribe = function(client, message) {
+  Resource.prototype.subscribe.call( this, client, message);
+  this.subscribers[client.id] = { listening: true };
+};
+
 Presence.prototype.unsubscribe = function(client, message) {
   logging.info('#presence - implicit disconnect', client.id, this.name);
   this.manager.disconnectClient(client.id);
@@ -178,7 +183,7 @@ Presence.prototype.broadcast = function(message, except) {
   var self = this;
   Object.keys(this.subscribers).forEach(function(subscriber) {
     var client = self.parent.server.clients[subscriber];
-    if(client && client.id != except && self.subscribers[client.id] === true) {
+    if(client && client.id != except && self.subscribers[client.id].listening) {
       client.send(message);
     } else {
       logging.warn('#client - not sending: ', (client && client.id), message,  except,

--- a/tests/client.presence.test.js
+++ b/tests/client.presence.test.js
@@ -156,6 +156,15 @@ describe('given two clients and a presence resource', function() {
       });
     });
 
+    it('does not implicitly subscribe to the presence', function(done) {
+      p = p.for_client(client);
+      var presence = client.presence('test').on(p.notify);
+      p.fail_on_any_message(0);
+      client.presence('test').set('online', function() {
+        setTimeout(done, 500);
+      });
+    });
+
     describe('with another client listening for notifications', function() {
       it('should remain online after a while if the state does not change', function(done) {
         client.presence('test').set('online', function() {

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -308,10 +308,9 @@ describe('given a presence resource',function() {
         assert.deepEqual(local[2],  { to: 'aaa', op: 'offline', value: { 1: 2 } });
         assert.deepEqual(local[2].value, { 1: 2 });
 
-        // each client should have received two messages, since we don't send client_offline
-        // notifications to the client itself.
-        assert.equal(messages[client.id].length, 2);
-        assert.equal(messages[client2.id].length, 2);
+        // no notifications sent to the client themselves.
+        assert.equal(typeof messages[client.id], 'undefined');
+        assert.equal(typeof messages[client2.id], 'undefined');
       });
 
       it('should emit a user disconnect only after both disconnect (both implicit)', function() {
@@ -354,10 +353,9 @@ describe('given a presence resource',function() {
         assert.equal(local[2].op, 'offline');
         assert.deepEqual(local[2].value, { 1: 2 });
 
-        // only CID 2 receives any messages
-        // = one message for the CID1 disconnect, after which no messages are delivered
+        // no notifications sent to the client themselves.
         assert.equal(typeof messages[client.id], 'undefined');
-        assert.equal(messages[client2.id].length, 1);
+        assert.equal(typeof messages[client2.id], 'undefined');
       });
 
       it('should emit a user disconnect only after both disconnect (one implicit, other explicit)', function() {
@@ -393,10 +391,9 @@ describe('given a presence resource',function() {
         assert.equal(local[2].op, 'offline');
         assert.deepEqual(local[2].value, { 1: 2 });
 
-        // only CID 2 receives any messages
-        // = two messages, one for CID 1 offline and one for UID1 offline
+        // no notifications sent to the client themselves.
         assert.equal(typeof messages[client.id], 'undefined');
-        assert.equal(messages[client2.id].length, 2);
+        assert.equal(typeof messages[client2.id], 'undefined');
       });
     });
   });


### PR DESCRIPTION
- By removing this implicit subscription,
we can now have presence resources where the 'present'
clients are not interested in the overall presences.
This allows 1000s of clients to go online on the same presence,
and makes it possible to read their collective state through API,
or allow limited number of subscribers to such resources (like
dashboards).

This is a big change to Presence API. Existing client usage must check for the old usage and be fixed.

/cc @zendesk/zendesk-radar

/cc @hsume2 @kruppel (This turned out to be much more easier than I thought)

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: 

### Risks
 - None
