### PR TITLE
Presence states

### DIFF
--- a/core/lib/resources/presence/index.js
+++ b/core/lib/resources/presence/index.js
@@ -119,14 +119,16 @@ Presence.prototype.set = function(client, message) {
     // we use subscribe/unsubscribe to trap the "close" event, so subscribe now
     this.subscribe(client);
     var state = message.value != 'online' ? message.value : null;
-    this.manager.addClient(client.id, userId, message.type, message.userData, state, ackCheck);
+    var userOpts = { userId: userId, userType: message.type, userData: message.userData, state: state };
+    this.manager.addClient(client.id, userOpts, ackCheck);
   } else {
     if(!this.subscribers[client.id]) { //if this is client is not subscribed
       //This is possible if a client does .set('offline') without set-online/sync/subscribe
       Resource.prototype.unsubscribe.call(this, client, message);
     } else {
       // remove from local
-      this.manager.removeClient(client.id, userId, message.type, ackCheck);
+      var userOpts = { userId: userId, userType: message.type };
+      this.manager.removeClient(client.id, userOpts, ackCheck);
     }
   }
 };

--- a/core/lib/resources/presence/index.js
+++ b/core/lib/resources/presence/index.js
@@ -118,7 +118,7 @@ Presence.prototype.set = function(client, message) {
   if(message.value != 'offline') {
     // we use subscribe/unsubscribe to trap the "close" event, so subscribe now
     this.subscribe(client);
-    var state = message.value != 'online' ? message.value : {};
+    var state = message.value != 'online' ? message.value : null;
     this.manager.addClient(client.id, userId, message.type, message.userData, state, ackCheck);
   } else {
     if(!this.subscribers[client.id]) { //if this is client is not subscribed

--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -107,24 +107,15 @@ PresenceManager.prototype.stampExpiration = function(message) {
   message.at = Date.now() + PresenceManager.messageExpiry;
 };
 
-PresenceManager.prototype.addClient = function(clientId, userId, userType, userData, state, callback) {
-  if(typeof callback === 'undefined') {
-    if (typeof state === 'function') {
-      callback = state;
-      state = null;
-    } else if (typeof state === 'undefined') {
-      state = null;
-    }
-  }
-
+PresenceManager.prototype.addClient = function(clientId, userOpts, callback) {
   var message = {
-    userId: userId,
-    userType: userType,
-    userData: userData,
+    userId:   userOpts.userId,
+    userType: userOpts.userType,
+    userData: userOpts.userData,
     clientId: clientId,
-    online: true,
-    state: state,
-    sentry: this.sentry.name
+    online:   true,
+    state:    userOpts.state,
+    sentry:   this.sentry.name
   };
 
   this.stampExpiration(message);
@@ -132,7 +123,7 @@ PresenceManager.prototype.addClient = function(clientId, userId, userType, userD
   //we might need the details before we actually do a store.add
   this.store.cacheAdd(clientId, message);
 
-  Persistence.persistHash(this.scope, userId + '.' + clientId, message);
+  Persistence.persistHash(this.scope, userOpts.userId + '.' + clientId, message);
 
   if(this.policy && this.policy.maxPersistence) {
     Persistence.expire(this.scope, this.policy.maxPersistence);
@@ -142,17 +133,17 @@ PresenceManager.prototype.addClient = function(clientId, userId, userType, userD
 };
 
 // explicit disconnect (set('offline'))
-PresenceManager.prototype.removeClient = function(clientId, userId, userType, callback) {
+PresenceManager.prototype.removeClient = function(clientId, userOpts, callback) {
   var message = {
-    userId: userId,
-    userType: userType,
+    userId:   userOpts.userId,
+    userType: userOpts.userType,
     clientId: clientId,
-    online: false,
+    online:   false,
     explicit: true
   };
   this.stampExpiration(message);
 
-  Persistence.deleteHash(this.scope, userId + '.' + clientId);
+  Persistence.deleteHash(this.scope, userOpts.userId + '.' + clientId);
   Persistence.publish(this.scope, message, callback);
 };
 

--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -108,6 +108,15 @@ PresenceManager.prototype.stampExpiration = function(message) {
 };
 
 PresenceManager.prototype.addClient = function(clientId, userId, userType, userData, state, callback) {
+  if(typeof callback === 'undefined') {
+    if (typeof state === 'function') {
+      callback = state;
+      state = null;
+    } else if (typeof state === 'undefined') {
+      state = null;
+    }
+  }
+
   var message = {
     userId: userId,
     userType: userType,
@@ -338,7 +347,10 @@ PresenceManager.prototype.getClientsOnline = function() {
 
   function processMessage(message) {
     result[message.userId] = result[message.userId] || { clients: { } , userType: message.userType };
-    result[message.userId].clients[message.clientId] = { userData: message.userData, state: message.state };
+    result[message.userId].clients[message.clientId] = {
+      userData: message.userData,
+      state: typeof message.state !== 'undefined' ? message.state : null
+    };
   }
 
   store.forEachClient(function(uid, cid, message) {

--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -114,7 +114,7 @@ PresenceManager.prototype.addClient = function(clientId, userOpts, callback) {
     userData: userOpts.userData,
     clientId: clientId,
     online:   true,
-    state:    userOpts.state,
+    state:    userOpts.state || null,
     sentry:   this.sentry.name
   };
 
@@ -340,7 +340,7 @@ PresenceManager.prototype.getClientsOnline = function() {
     result[message.userId] = result[message.userId] || { clients: { } , userType: message.userType };
     result[message.userId].clients[message.clientId] = {
       userData: message.userData,
-      state: typeof message.state !== 'undefined' ? message.state : null
+      state: message.state
     };
   }
 

--- a/core/lib/resources/presence/presence_store.js
+++ b/core/lib/resources/presence/presence_store.js
@@ -37,6 +37,12 @@ PresenceStore.prototype.add = function(clientId, userId, userType, data) {
     events.push('client_added');
     this.map[userId][clientId] = data;
     this.clientUserMap[clientId] = userId;
+  } else {
+    state_str = JSON.stringify(this.map[userId][clientId].state);
+    if(state_str != JSON.stringify(data.state)) {
+      events.push('client_updated');
+      this.map[userId][clientId].state = data.state;
+    }
   }
 
   events.forEach(function(ev) {
@@ -54,6 +60,7 @@ PresenceStore.prototype.remove = function(clientId, userId, data) {
   if(!this.map[userId] || !this.map[userId][clientId]) {
     return; //inexistant, return
   }
+  data.state = this.map[userId][clientId].state;
 
   events.push('client_removed');
   delete this.map[userId][clientId];
@@ -78,6 +85,9 @@ PresenceStore.prototype.removeClient = function(clientId, data) {
   if(!userId) {
     logging.warn('#presence - store.removeClient: cannot find data for', clientId, this.scope);
     return; //inexistant, return
+  }
+  if(this.map[userId][clientId]) {
+    data.state = this.map[userId][clientId].state;
   }
   logging.debug('#presence - store.removeClient', userId, clientId, data, this.scope);
   delete this.map[userId][clientId];

--- a/tests/client.presence.remote.test.js
+++ b/tests/client.presence.remote.test.js
@@ -14,6 +14,8 @@ describe('given a client and a server,', function() {
   var p, sentry = new Sentry('test-sentry');
   var presenceManager = new PresenceManager('presence:/dev/test',{}, sentry);
   var stampExpiration = presenceManager.stampExpiration;
+  var abc_opts = { userId: 100, userType: 2, userData: { name: 'tester' }, state: null };
+
   before(function(done) {
     common.startPersistence(function() {
       radar = common.spawnRadar();
@@ -72,7 +74,7 @@ describe('given a client and a server,', function() {
           p.assert_message_sequence([ 'online', 'client_online' ]);
           done();
         };
-        presenceManager.addClient('abc', 100, 2, { name: 'tester' });
+        presenceManager.addClient('abc', abc_opts);
 
         p.fail_on_more_than(2);
         p.on(2, function() {
@@ -85,8 +87,8 @@ describe('given a client and a server,', function() {
           p.assert_message_sequence([ 'online', 'client_online' ]);
           done();
         };
-        presenceManager.addClient('abc', 100, 2, { name: 'tester' });
-        presenceManager.addClient('abc', 100, 2, { name: 'tester' });
+        presenceManager.addClient('abc', abc_opts);
+        presenceManager.addClient('abc', abc_opts);
         p.on(2, function() {
           setTimeout(validate, 20);
         });
@@ -94,7 +96,7 @@ describe('given a client and a server,', function() {
 
       it('should ignore messages from dead servers (sentry expired and gone)', function(done) {
         sentry.name = 'dead';
-        presenceManager.addClient('abc', 100, 2, { name: 'tester' });
+        presenceManager.addClient('abc', abc_opts);
         p.fail_on_any_message();
         setTimeout(done, 10);
       });
@@ -102,7 +104,7 @@ describe('given a client and a server,', function() {
       it('should ignore messages from dead servers (sentry expired but not gone)', function(done) {
         sentry.name = 'expired';
         sentry.publishKeepAlive({ expiration: Date.now() - 10});
-        presenceManager.addClient('abc', 100, 2, { name: 'tester' });
+        presenceManager.addClient('abc', abc_opts);
         p.fail_on_any_message();
         setTimeout(done, 10);
       });
@@ -117,7 +119,7 @@ describe('given a client and a server,', function() {
             p.assert_message_sequence([ 'online', 'client_online' ]);
             done();
           };
-          presenceManager.addClient('abc', 100, 2, { name: 'tester' });
+          presenceManager.addClient('abc', abc_opts);
 
           p.fail_on_more_than(2);
           p.on(2, function() {
@@ -129,7 +131,7 @@ describe('given a client and a server,', function() {
           presenceManager.stampExpiration = function(message) {
             message.at = Date.now() - 5000;
           };
-          presenceManager.addClient('abc', 100, 2, { name: 'tester' });
+          presenceManager.addClient('abc', abc_opts);
           p.fail_on_any_message();
           setTimeout(done, 10);
         });
@@ -137,7 +139,7 @@ describe('given a client and a server,', function() {
     });
     describe('for incoming offline messages,', function() {
       beforeEach(function(done) {
-        presenceManager.addClient('abc', 100, 2, { name: 'tester' }, done);
+        presenceManager.addClient('abc', abc_opts, done);
       });
 
       it('should emit user/client offline for explicit disconnect', function(done) {
@@ -145,7 +147,7 @@ describe('given a client and a server,', function() {
           p.assert_message_sequence([ 'online', 'client_online', 'client_explicit_offline', 'offline' ]);
           done();
         };
-        presenceManager.removeClient('abc', 100, 2);
+        presenceManager.removeClient('abc', abc_opts);
         p.on(4, function() {
           setTimeout(validate,10);
         });
@@ -156,8 +158,8 @@ describe('given a client and a server,', function() {
           p.assert_message_sequence([ 'online', 'client_online', 'client_explicit_offline', 'offline' ]);
           done();
         };
-        presenceManager.removeClient('abc', 100, 2);
-        presenceManager.removeClient('abc', 100, 2);
+        presenceManager.removeClient('abc', abc_opts);
+        presenceManager.removeClient('abc', abc_opts);
         p.on(4, function() {
           setTimeout(validate, 10);
         });
@@ -201,21 +203,26 @@ describe('given a client and a server,', function() {
 
 
   describe('with existing persistence entries, ', function() {
-    var clients = {};
-    beforeEach(function(done) {
-      sentry.name = 'server1';
-      sentry.publishKeepAlive();
-      presenceManager.addClient('abc', 100, 2, { name: 'tester1' });
-      sentry.name = 'server2';
-      sentry.publishKeepAlive();
-      presenceManager.addClient('def', 200, 0, { name: 'tester2' }, done);
-      clients =  {
+    var clients =  {
         abc: { clientId: 'abc', userId: 100, userType: 2, userData: { name: 'tester1' } },
         def: { clientId: 'def', userId: 200, userType: 0, userData: { name: 'tester2' } },
         hij: { clientId: 'hij', userId: 300, userType: 2, userData: { name: 'tester3' } },
         pqr: { clientId: 'pqr', userId: 100, userType: 2, userData: { name: 'tester1' } },
         klm: { clientId: 'klm', userId: 400, userType: 2, userData: { name: 'tester4' } }
       };
+    var abc_opts = { userId: 100, userType: 2, userData: { name: 'tester1' }, state: null };
+    var def_opts = { userId: 200, userType: 0, userData: { name: 'tester2' }, state: null };
+    var hij_opts = { userId: 300, userType: 2, userData: { name: 'tester3' }, state: null };
+    var pqr_opts = { userId: 100, userType: 2, userData: { name: 'tester1' }, state: null };
+    var klm_opts = { userId: 400, userType: 2, userData: { name: 'tester4' }, state: null };
+
+    beforeEach(function(done) {
+      sentry.name = 'server1';
+      sentry.publishKeepAlive();
+      presenceManager.addClient('abc', abc_opts);
+      sentry.name = 'server2';
+      sentry.publishKeepAlive();
+      presenceManager.addClient('def', def_opts, done);
     });
 
     describe('when syncing (v2), ', function() {
@@ -246,7 +253,7 @@ describe('given a client and a server,', function() {
           assert.ok(callback);
           done();
         };
-        presenceManager.addClient('pqr', 100, 2, { name: 'tester1' }, function() {
+        presenceManager.addClient('pqr', pqr_opts, function() {
           client.presence('test').on(p.notify).sync({ version: 2 }, function(message) {
             p.for_online_clients(clients.abc, clients.def, clients.pqr)
               .assert_sync_v2_response(message);
@@ -281,7 +288,7 @@ describe('given a client and a server,', function() {
         p.on(4, function() {
           sentry.name = 'server1';
           sentry.publishKeepAlive();
-          presenceManager.addClient('hij', 300, 2, { name: 'tester3' });
+          presenceManager.addClient('hij', hij_opts);
         });
 
         p.fail_on_more_than(6);
@@ -299,7 +306,7 @@ describe('given a client and a server,', function() {
         };
 
         sentry.name = 'unknown';
-        presenceManager.addClient('klm', 400, 2, { name: 'tester4' }, function() {
+        presenceManager.addClient('klm', klm_opts, function() {
           client.presence('test').on(p.notify).sync({ version: 2 }, function(message) {
             p.for_online_clients(clients.abc, clients.def).assert_sync_v2_response(message);
             callback = true;
@@ -322,7 +329,7 @@ describe('given a client and a server,', function() {
 
         sentry.name = 'expired';
         sentry.publishKeepAlive({ expiration: Date.now() - 10});
-        presenceManager.addClient('klm', 400, 2, { name: 'tester4' }, function() {
+        presenceManager.addClient('klm', klm_opts, function() {
           client.presence('test').on(p.notify).sync({ version: 2 }, function(message) {
             p.for_online_clients(clients.abc, clients.def)
               .assert_sync_v2_response(message);
@@ -349,7 +356,7 @@ describe('given a client and a server,', function() {
             message.at = Date.now();
           };
 
-          presenceManager.addClient('klm', 400, 2, { name: 'tester4' }, function() {
+          presenceManager.addClient('klm', klm_opts, function() {
             client.presence('test').on(p.notify).sync({ version: 2 }, function(message) {
               p.for_online_clients(clients.abc, clients.def, clients.klm)
                 .assert_sync_v2_response(message);
@@ -376,7 +383,7 @@ describe('given a client and a server,', function() {
             message.at = Date.now() - 30000;
           };
 
-          presenceManager.addClient('klm', 400, 2, { name: 'tester4' }, function() {
+          presenceManager.addClient('klm', klm_opts, function() {
             client.presence('test').on(p.notify).sync({ version: 2 }, function(message) {
               p.for_online_clients(clients.abc, clients.def)
                 .assert_sync_v2_response(message);
@@ -429,7 +436,7 @@ describe('given a client and a server,', function() {
           // After sync's online has come, add another client
           sentry.name = 'server1';
           sentry.publishKeepAlive();
-          presenceManager.addClient('hij', 300, 2, { name: 'tester3' });
+          presenceManager.addClient('hij', hij_opts);
         });
 
         p.on(6, function() {
@@ -454,7 +461,7 @@ describe('given a client and a server,', function() {
 
       it('should ignore dead server clients (sentry expired and gone)', function(done) {
         sentry.name = 'unknown';
-        presenceManager.addClient('klm', 400, 2, { name: 'tester4' }, function() {
+        presenceManager.addClient('klm', klm_opts, function() {
           client.presence('test').on(p.notify).get(function(message) {
             p.for_online_clients(clients.abc, clients.def)
               .assert_get_response(message);
@@ -468,7 +475,7 @@ describe('given a client and a server,', function() {
       it('should ignore dead server clients (sentry expired but not gone)', function(done) {
         sentry.name = 'expired';
         sentry.publishKeepAlive({ expiration: Date.now() - 10});
-        presenceManager.addClient('klm', 400, 2, { name: 'tester4' }, function() {
+        presenceManager.addClient('klm', klm_opts, function() {
           client.presence('test').on(p.notify).get(function(message) {
             p.for_online_clients(clients.abc, clients.def)
               .assert_get_response(message);
@@ -488,7 +495,7 @@ describe('given a client and a server,', function() {
             message.at = Date.now();
           };
 
-          presenceManager.addClient('klm', 400, 2, { name: 'tester4' }, function() {
+          presenceManager.addClient('klm', klm_opts, function() {
             client.presence('test').on(p.notify).get(function(message) {
               p.for_online_clients(clients.abc, clients.def, clients.klm)
                 .assert_get_response(message);
@@ -505,7 +512,7 @@ describe('given a client and a server,', function() {
             message.at = Date.now() - 5000;
           };
 
-          presenceManager.addClient('klm', 400, 2, { name: 'tester4' }, function() {
+          presenceManager.addClient('klm', klm_opts, function() {
             client.presence('test').on(p.notify).get(function(message) {
               p.for_online_clients(clients.abc, clients.def)
                 .assert_get_response(message);

--- a/tests/client.presence.sentry.test.js
+++ b/tests/client.presence.sentry.test.js
@@ -14,7 +14,8 @@ describe('given a client and a server,', function() {
   var p, sentry = new Sentry('test-sentry');
   var presenceManager = new PresenceManager('presence:/dev/test', {}, sentry);
   var publish_client_online = function(client) {
-    presenceManager.addClient(client.clientId, client.userId, client.userType, client.userData);
+    var userOpts = { userId: client.userId, userType: client.userType, userData: client.userData, state: null };
+    presenceManager.addClient(client.clientId, userOpts);
   };
   var publish_autopub = function(client) {
     delete sentry.name;

--- a/tests/lib/assert_helper.js
+++ b/tests/lib/assert_helper.js
@@ -97,7 +97,8 @@ PresenceMessage.prototype.assert_client_online = function(message) {
   var value = {
     userId: client.userId,
     clientId: client.clientId,
-    userData: client.userData
+    userData: client.userData,
+    state: {}
   };
 
   assert.deepEqual({
@@ -121,7 +122,8 @@ PresenceMessage.prototype.assert_client_offline = function(message, explicit) {
   var client = this.client;
   var value = {
     userId: client.userId,
-    clientId: client.clientId
+    clientId: client.clientId,
+    state: {}
   };
 
   assert.deepEqual({
@@ -244,7 +246,7 @@ PresenceMessage.prototype.assert_get_v2_response = function(message) {
     } else {
       value[client.userId] = userHash = { clients: {} };
     }
-    userHash.clients[client.clientId] = client.userData;
+    userHash.clients[client.clientId] = { userData: client.userData, state: {} };
     userHash.userType = client.userType;
   });
 

--- a/tests/lib/assert_helper.js
+++ b/tests/lib/assert_helper.js
@@ -98,7 +98,7 @@ PresenceMessage.prototype.assert_client_online = function(message) {
     userId: client.userId,
     clientId: client.clientId,
     userData: client.userData,
-    state: {}
+    state: message.value.state
   };
 
   assert.deepEqual({
@@ -123,7 +123,7 @@ PresenceMessage.prototype.assert_client_offline = function(message, explicit) {
   var value = {
     userId: client.userId,
     clientId: client.clientId,
-    state: {}
+    state: message.value.state
   };
 
   assert.deepEqual({
@@ -246,15 +246,18 @@ PresenceMessage.prototype.assert_get_v2_response = function(message) {
     } else {
       value[client.userId] = userHash = { clients: {} };
     }
-    userHash.clients[client.clientId] = { userData: client.userData, state: {} };
+    userHash.clients[client.clientId] = {
+      userData: client.userData,
+      state: message.state
+    };
     userHash.userType = client.userType;
   });
 
-  assert.deepEqual({
+  assert.deepEqual(message, {
     op: 'get',
     to: this.scope,
     value: value
-  }, message, JSON.stringify(value)+' vs '+JSON.stringify(message.value));
+  });
 };
 
 // sync response:

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -296,13 +296,13 @@ describe('given a presence resource',function() {
         assert.deepEqual(local[0],{ to: 'aaa',
           op: 'client_offline',
           explicit: true,
-          value: { userId: 1, clientId: client.id }
+          value: { userId: 1, clientId: client.id, state: {} }
         });
         // there should be a client_offline notification for CID 2
         assert.deepEqual(local[1],{ to: 'aaa',
           op: 'client_offline',
           explicit: true,
-          value: { userId: 1, clientId: client2.id }
+          value: { userId: 1, clientId: client2.id, state: {} }
         });
         // there should be a broadcast for a offline notification for UID 1
         assert.deepEqual(local[2],  { to: 'aaa', op: 'offline', value: { 1: 2 } });

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -296,13 +296,13 @@ describe('given a presence resource',function() {
         assert.deepEqual(local[0],{ to: 'aaa',
           op: 'client_offline',
           explicit: true,
-          value: { userId: 1, clientId: client.id, state: {} }
+          value: { userId: 1, clientId: client.id, state: null }
         });
         // there should be a client_offline notification for CID 2
         assert.deepEqual(local[1],{ to: 'aaa',
           op: 'client_offline',
           explicit: true,
-          value: { userId: 1, clientId: client2.id, state: {} }
+          value: { userId: 1, clientId: client2.id, state: null }
         });
         // there should be a broadcast for a offline notification for UID 1
         assert.deepEqual(local[2],  { to: 'aaa', op: 'offline', value: { 1: 2 } });
@@ -420,7 +420,7 @@ describe('given a presence resource',function() {
     it('userData should be included as the value of a client in a presence response', function() {
       var data = {
             clients: {},
-            userType: 2,
+            userType: 2
           },
           fakeClient = {
             send: function(msg) {
@@ -428,7 +428,7 @@ describe('given a presence resource',function() {
             }
           };
 
-      data.clients[client.id] = { test: 1 };
+      data.clients[client.id] = { userData: { test: 1 }, state: null };
 
       presence.set(client, { type: 2, key: 123, value: 'online', userData: { test: 1 } });
       presence.get(fakeClient, { options: { version: 2 } });

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -26,6 +26,8 @@ describe('given a presence resource',function() {
   beforeEach(function(done) {
     Persistence.delWildCard('*', function() {
       Presence.sentry.start();
+      Presence.sentry.setMaxListeners(1000);
+
       presence = new Presence('aaa', Server, {});
       client = new MiniEE();
       client.send = function() {};

--- a/tests/radar_api.test.js
+++ b/tests/radar_api.test.js
@@ -213,7 +213,7 @@ exports['Radar api tests'] = {
       Client.get('/node/radar/presence')
         .data({ accountName: 'test', scope: 'ticket/1', version: 2 })
         .end(function(error, response) {
-          assert.deepEqual( {'1':{'clients':{'1000':{}},'userType':0}}, response);
+          assert.deepEqual( {'1':{'clients':{'1000':{'state': null}},'userType':0}}, response);
           done();
         });
     },
@@ -222,7 +222,7 @@ exports['Radar api tests'] = {
       Client.get('/node/radar/presence')
         .data({ accountName: 'test', scopes: 'ticket/1,ticket/2', version: 2 })
         .end(function(error, response) {
-          assert.deepEqual({ 'ticket/1': {'1':{'clients':{'1000':{}},'userType':0}}, 'ticket/2':{'2':{'clients':{'1001':{}},'userType':4}}}, response);
+          assert.deepEqual({ 'ticket/1': {'1':{'clients':{'1000':{'state':null}},'userType':0}}, 'ticket/2':{'2':{'clients':{'1001':{'state':null}},'userType':4}}}, response);
           done();
         });
     },


### PR DESCRIPTION
Experimental! This changes the Sync v2 response, as well as adds a new presence event. Also adds the state key to usual presence updates.

Instead of just set('online'), this supports presence.set(state). To accommodate for change in state, a new event "client_updated" is emitted. This is a long asked for feature, but thanks to the presence rewrite, it is pretty straight forward to implement. This should free up some interesting use-cases related to Presence, though I fear this will breed high traffic centralized presence resources too much.

For example: All clients go online on a central resource with state set to say, currently open ticket. By looking at the resource through API, we can list out all open tickets. By subscribing to that resource, it should be possible to watch tickets opening and closing. Subscription should be done by very few consumers, because a central resource will usually be very high traffic. Let me know what you think.

@kruppel @hsume2 
/cc @zendesk/zendesk-radar


### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: 

### Risks
 - None