### PR TITLE
Sentry down chain should exit when presence manager is being destroyed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.13.0
 * Set(online) for presence no longer subscribes to the resource.
     - This is a breaking change if the client assumes this behavior
+* Fix error where sentryDownForClient sometimes fails on undefined store reference
 
 ### 0.12.5
 * Expose details of sentry down in the listener

--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -41,25 +41,12 @@ PresenceManager.prototype.setup = function() {
 
   // save so you removeListener on destroy
   this.sentryListener = function (sentry) {
-    if (manager.destroying) return;
-
     var clientIds = store.clientsForSentry(sentry);
 
     var chain = function (clientIds) {
-      var immediateObject;
       var clientId = clientIds.pop();
 
-      // Pick up any new users/clients that have subscribed to this resource
-      if (!clientId && !manager.destroying) {
-        clientIds = store.clientsForSentry(sentry);
-        clientId = clientIds.pop();
-      }
-
       if (!clientId || manager.destroying) {
-        if (immediateObject) {
-          clearImmediate(immediateObject);
-        }
-
         logging.info('#presence - #sentry down chain exit: clientId:',
                       clientId, ', manager.destroying:', manager.destroying);
         return;
@@ -71,6 +58,7 @@ PresenceManager.prototype.setup = function() {
         chain(clientIds);
       });
     };
+
     chain(clientIds);
   };
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "radar_client": "0.12.1",
+    "radar_client": "0.13.0",
     "simple_sentinel": "*"
   },
   "scripts": {


### PR DESCRIPTION
When PresenceManager is handling a sentry "down" event for a given presence, make sure that collateral removal of the underlying presence doesn't cause the sentry down chain to fail on an undefined PresenceStore reference.  This scenario occurs intermittently, for example, when sentry is processing a down event while radar server is still handling local client online/offline events.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-443

### Risks
 - Low: handling of sentry down events breaks in unexpected ways, or stops working altogether