### PR TITLE
Clean up code by renaming objects more precisely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ script:
 notifications:
   flowdock:
     secure: eqo+1HteeVzHGckSQhvSG18sD7Eq/DdFSouaW3Mj7owW8gH83/utYgCU2DOiSn404wOqIv2MgI+CYzgoFQCoYaR98BgxYS2iike1GWkn+s53VFSS9WNkjWW/4W7Fm+g4fWEDnN00U4mIJK3G/9l+C2zDiSaRwuD+9K61o3QCWaM=
+branches:
+  only: [master, staging, production]

--- a/api/apis/radar.js
+++ b/api/apis/radar.js
@@ -118,7 +118,7 @@ function getPresence(req, res) {
       q = parts.query;
   if(!q || !q.accountName) { return res.end(); }
   if(!(q.scope || q.scopes)) { return res.end(); }
-  // sadly, the responses are different when dealing with multiple scopes so can't just put these in a control flow
+  // Sadly, the responses are different when dealing with multiple scopes so can't just put these in a control flow
   if(q.scope) {
     var monitor = new PresenceManager('presence:/'+q.accountName+'/'+q.scope, {}, Presence.sentry);
     monitor.fullRead(function(online) {

--- a/api/apis/radar.js
+++ b/api/apis/radar.js
@@ -23,7 +23,7 @@ function parseData(response, data, ResourceType) {
     }
   }
 
-  if(!parameters || !parameters.accountName || !parameters.scope) {
+  if (!parameters || !parameters.accountName || !parameters.scope) {
     return jsonResponse(response, {});
   }
 
@@ -116,16 +116,16 @@ function getMessage(req, res) {
 function getPresence(req, res) {
   var parts = url.parse(req.url, true),
       q = parts.query;
-  if(!q || !q.accountName) { return res.end(); }
-  if(!(q.scope || q.scopes)) { return res.end(); }
+  if (!q || !q.accountName) { return res.end(); }
+  if (!(q.scope || q.scopes)) { return res.end(); }
   // Sadly, the responses are different when dealing with multiple scopes so can't just put these in a control flow
-  if(q.scope) {
+  if (q.scope) {
     var monitor = new PresenceManager('presence:/'+q.accountName+'/'+q.scope, {}, Presence.sentry);
     monitor.fullRead(function(online) {
       res.setHeader('Content-type', 'application/json');
       res.setHeader('Cache-Control', 'no-cache');
       res.setHeader('X-Radar-Host', hostname);
-      if(q.version == 2) {
+      if (q.version == 2) {
         res.end(JSON.stringify(monitor.getClientsOnline())+'\n');
       } else {
         res.end(JSON.stringify(online)+'\n');
@@ -137,7 +137,7 @@ function getPresence(req, res) {
     scopes.forEach(function(scope) {
       var monitor = new PresenceManager('presence:/'+q.accountName+'/'+scope, {}, Presence.sentry);
       monitor.fullRead(function(online) {
-        if(q.version == 2) {
+        if (q.version == 2) {
           result[scope] = monitor.getClientsOnline();
         } else {
           result[scope] = online;

--- a/api/lib/client.js
+++ b/api/lib/client.js
@@ -6,7 +6,7 @@ var https = require('https'),
     logging = require('minilog')('client');
 
 function Scope(defaults) {
-  // clone Client.def. We don't want to change the defaults when we modify options further.
+  // Clone Client.def. We don't want to change the defaults when we modify options further.
   this.defaults = JSON.parse(JSON.stringify(defaults));
 }
 
@@ -48,7 +48,7 @@ Client.prototype.header = function(key, value) {
 
 Client.prototype.data = function(data) {
   if(this.options.method == 'GET') {
-    // append to QS
+    // Append to QS
     logging.debug('GET append', data);
     this.options.path += '?'+qs.stringify(data);
   } else {
@@ -100,7 +100,7 @@ Client.prototype._end = function(callback) {
         }
       }
 
-      // detect errors
+      // Detect errors
       if(response.statusCode >= 400) {
         return self._error(new Error('Unexpected HTTP status code ' +response.statusCode), res_data, callback);
       } else if(res_data == '') {
@@ -132,7 +132,7 @@ Client.prototype._redirect = function(response) {
     response.headers.location = urlmodule.resolve(options.url, response.headers.location);
   }
 
-  // parse location to check for port
+  // Parse location to check for port
   parts = urlmodule.parse(response.headers.location);
   if(parts.protocol == 'http:') {
     options.secure = false;

--- a/api/lib/client.js
+++ b/api/lib/client.js
@@ -47,7 +47,7 @@ Client.prototype.header = function(key, value) {
 };
 
 Client.prototype.data = function(data) {
-  if(this.options.method == 'GET') {
+  if (this.options.method == 'GET') {
     // Append to QS
     logging.debug('GET append', data);
     this.options.path += '?'+qs.stringify(data);
@@ -73,7 +73,7 @@ Client.prototype._end = function(callback) {
       res_data = '',
       protocol = (secure ? https : http);
 
-  if(this.beforeRequest) {
+  if (this.beforeRequest) {
     this.beforeRequest(this);
   }
 
@@ -87,12 +87,12 @@ Client.prototype._end = function(callback) {
 
       logging.debug('Response for the request "'+options.method+' '+options.host + options.path+'" has been ended.');
 
-      if(isRedirect && self.options.redirects == 0) {
+      if (isRedirect && self.options.redirects == 0) {
         logging.debug('Redirect to: ', response.headers.location);
         return self._redirect(response);
       }
 
-      if(response.headers['content-type'] && response.headers['content-type'].toLowerCase().indexOf('application/json') > -1 ) {
+      if (response.headers['content-type'] && response.headers['content-type'].toLowerCase().indexOf('application/json') > -1 ) {
         try {
           res_data = JSON.parse(res_data);
         } catch(jsonParseError) {
@@ -101,9 +101,9 @@ Client.prototype._end = function(callback) {
       }
 
       // Detect errors
-      if(response.statusCode >= 400) {
+      if (response.statusCode >= 400) {
         return self._error(new Error('Unexpected HTTP status code ' +response.statusCode), res_data, callback);
-      } else if(res_data == '') {
+      } else if (res_data == '') {
         return self._error(new Error('Response was empty.'), res_data, callback);
       }
 
@@ -134,7 +134,7 @@ Client.prototype._redirect = function(response) {
 
   // Parse location to check for port
   parts = urlmodule.parse(response.headers.location);
-  if(parts.protocol == 'http:') {
+  if (parts.protocol == 'http:') {
     options.secure = false;
     options.port = parts.port || 80;
   }

--- a/api/lib/router.js
+++ b/api/lib/router.js
@@ -15,17 +15,17 @@ Router.prototype.route = function(req, res) {
       urlHandler, matching;
 
   while(++i <= len){
-    if(this.urlMap[i] && this.urlMap[i].method == req.method && this.urlMap[i].re.test(pathname)){
+    if (this.urlMap[i] && this.urlMap[i].method == req.method && this.urlMap[i].re.test(pathname)){
       urlHandler = this.urlMap[i];
       break;
     }
   }
 
-  if(!urlHandler) {
+  if (!urlHandler) {
     return false;
   }
 
-  if(req.method == 'POST') {
+  if (req.method == 'POST') {
     var data = '';
 
     req.on('data', function(chunk) {
@@ -60,7 +60,7 @@ Router.prototype.attach = function(httpServer) {
 
   // Add request handler
   httpServer.on('request', function (req, res) {
-    if(!self.route(req, res)) {
+    if (!self.route(req, res)) {
       logging.info('Routing to old listeners');
       for (var i = 0, l = oldListeners.length; i < l; i++) {
         oldListeners[i].call(httpServer, req, res);

--- a/api/lib/router.js
+++ b/api/lib/router.js
@@ -54,11 +54,11 @@ Router.prototype.post = function(regexp, callback) {
 
 Router.prototype.attach = function(httpServer) {
   var self = this,
-      // cache and clean up listeners
+      // Cache and clean up listeners
       oldListeners = httpServer.listeners('request');
   httpServer.removeAllListeners('request');
 
-  // add request handler
+  // Add request handler
   httpServer.on('request', function (req, res) {
     if(!self.route(req, res)) {
       logging.info('Routing to old listeners');

--- a/configuration.js
+++ b/configuration.js
@@ -1,10 +1,10 @@
 module.exports = {
-  // default (optional)
+  // Default (optional)
   // Will fallback to localhost:6379
   redis_host: 'localhost',
   redis_port: 6379,
 
-  // (optional) Only usable if you define use_connection.
+  // (Optional) Only usable if you define use_connection.
   // Lets you specify a number of redis options and pick one.
   connection_settings: {
     legacy: {
@@ -12,7 +12,7 @@ module.exports = {
       port: 6379
     },
     cluster1: {
-      // sentinel master name is required
+      // Sentinel master name is required
       id: 'mymaster',
       sentinels: [
       {
@@ -39,13 +39,13 @@ module.exports = {
   },
 
   // Only used if a connection_settings hash is present.
-  // (optional). will fallback to default if not present.
+  // (Optional). will fallback to default if not present.
   //use_connection: 'legacy',
 
-  //Radar config: Port for radar to run on.
+  // Radar config: Port for radar to run on.
   port: 8000,
 
-  //Radar config: (optional), not currently set, interval for datadog reporting
+  // Radar config: (optional), not currently set, interval for datadog reporting
   healthReportInterval: 10000,
 };
 

--- a/core/lib/resource.js
+++ b/core/lib/resource.js
@@ -71,25 +71,14 @@ Resource.prototype.unsubscribe = function(client, message) {
   this.ack(client, message && message.ack);
 };
 
-var noop = function(name) {
-  return function() {
-    logging.error('#'+this.type+ '- undefined_method called for resource',
-                                                              name, this.name);
-  };
-};
-
-'get set sync publish'.split(' ').forEach(function(method) {
-  Resource.prototype[method] = noop(method);
-});
-
 // Send to Engine.io clients
 Resource.prototype.redisIn = function(data) {
   var self = this;
   logging.info('#'+this.type, '- incoming from #redis', this.name, data, 'subs:',
                                           Object.keys(this.subscribers).length );
 
-  Object.keys(this.subscribers).forEach(function(subscriber) {
-    var client = self.clientGet(subscriber);
+  Object.keys(this.subscribers).forEach(function(clientId) {
+    var client = self.clientGet(clientId);
     if (client && client.send) {
       client.send(data);
     }

--- a/core/lib/resource.js
+++ b/core/lib/resource.js
@@ -60,7 +60,7 @@ Resource.prototype.unsubscribe = function(client, message) {
 
   if (!Object.keys(this.subscribers).length) {
     logging.info('#'+this.type, '- destroying resource', this.name, this.subscribers, client.id);
-    this.parent.destroy(this.name);
+    this.parent.destroyResource(this.name);
   }
 
   this.ack(client, message && message.ack);

--- a/core/lib/resources/message_list.js
+++ b/core/lib/resources/message_list.js
@@ -29,9 +29,9 @@ MessageList.prototype.publish = function(client, message) {
 };
 
 MessageList.prototype._publish = function(name, policy, message, callback) {
-  if(policy && policy.cache) {
+  if (policy && policy.cache) {
     Persistence.persistOrdered(name, message);
-    if(policy.maxPersistence) {
+    if (policy.maxPersistence) {
       Persistence.expire(name, policy.maxPersistence);
     }
   }
@@ -53,7 +53,7 @@ MessageList.prototype.sync = function(client, message) {
 };
 
 MessageList.prototype._sync = function(name, policy, callback) {
-  if(policy && policy.maxPersistence) {
+  if (policy && policy.maxPersistence) {
     Persistence.expire(name, policy.maxPersistence);
   }
   Persistence.readOrderedWithScores(name, policy, callback);

--- a/core/lib/resources/message_list.js
+++ b/core/lib/resources/message_list.js
@@ -7,6 +7,7 @@ var default_options = {
     maxPersistence: 14 * 24 * 60 * 60 // 2 weeks in seconds
   }
 };
+
 // Every time we use this channel, we prolong expiry to maxPersistence
 // This includes even the final unsubscribe, in case a client decides to rejoin
 // after being the last user.
@@ -60,10 +61,12 @@ MessageList.prototype._sync = function(name, policy, callback) {
 
 MessageList.prototype.unsubscribe = function(client, message) {
   Resource.prototype.unsubscribe.call(this, client, message);
-  // note that since this is not synchronized across multiple backend servers, it is possible
-  // for a channel that is subscribed elsewhere to have a TTL set on it again. The assumption is that the
-  // TTL is so long that any normal workflow will terminate before it is triggered.
-  if (this.options && this.options.policy && this.options.policy.cache && this.options.policy.maxPersistence) {
+  // Note that since this is not synchronized across multiple backend servers,
+  // it is possible for a channel that is subscribed elsewhere to have a TTL set
+  // on it again. The assumption is that the TTL is so long that any normal
+  // workflow will terminate before it is triggered.
+  if (this.options && this.options.policy && this.options.policy.cache &&
+                                      this.options.policy.maxPersistence) {
     Persistence.expire(this.name, this.options.policy.maxPersistence);
   }
 };

--- a/core/lib/resources/presence/index.js
+++ b/core/lib/resources/presence/index.js
@@ -85,7 +85,7 @@ Presence.prototype.setup = function() {
   // Keep track of listener count
   Presence.resource_count++;
   var sentryListenersCount = EventEmitter.listenerCount(Presence.sentry, 'down');
-  if(sentryListenersCount != Presence.resource_count) {
+  if (sentryListenersCount != Presence.resource_count) {
     logging.warn('sentry listener leak detected', sentryListenersCount -
                                                   Presence.resource_count);
   }
@@ -105,12 +105,12 @@ Presence.prototype.set = function(client, message) {
     presence.ack(client, message.ack);
   }
 
-  if(message.value != 'offline') {
+  if (message.value != 'offline') {
     this._set_online(client);
     this.manager.addClient(client.id, userId, message.type, message.userData, ackCheck);
   } else {
     // If this is client is not subscribed
-    if(!this.subscribers[client.id]) {
+    if (!this.subscribers[client.id]) {
       // This is possible if a client does .set('offline') without
       // set-online/sync/subscribe
       Resource.prototype.unsubscribe.call(this, client, message);
@@ -122,7 +122,7 @@ Presence.prototype.set = function(client, message) {
 };
 
 Presence.prototype._set_online = function(client) {
-  if(!this.subscribers[client.id]) {
+  if (!this.subscribers[client.id]) {
     // We use subscribe/unsubscribe to trap the "close" event, so subscribe now
     this.subscribe(client);
 
@@ -147,7 +147,7 @@ Presence.prototype.unsubscribe = function(client, message) {
 Presence.prototype.sync = function(client, message) {
   var self = this;
   this.fullRead(function(online) {
-    if(message.options && message.options.version == 2) {
+    if (message.options && message.options.version == 2) {
       client.send({
         op: 'get',
         to: self.name,
@@ -172,7 +172,7 @@ Presence.prototype.sync = function(client, message) {
 Presence.prototype.get = function(client, message) {
   var self = this;
   this.fullRead(function(online) {
-    if(message.options && message.options.version == 2) {
+    if (message.options && message.options.version == 2) {
       client.send({
         op: 'get',
         to: self.name,
@@ -193,7 +193,7 @@ Presence.prototype.broadcast = function(message, except) {
   var self = this;
   Object.keys(this.subscribers).forEach(function(subscriber) {
     var client = self.clientGet(subscriber);
-    if(client && client.id != except && self.subscribers[client.id].listening) {
+    if (client && client.id != except && self.subscribers[client.id].listening) {
       client.send(message);
     } else {
       logging.warn('#client - not sending: ', (client && client.id), message,  except,

--- a/core/lib/resources/presence/index.js
+++ b/core/lib/resources/presence/index.js
@@ -191,8 +191,8 @@ Presence.prototype.get = function(client, message) {
 Presence.prototype.broadcast = function(message, except) {
   logging.debug('#presence - update subscribed clients', message, except, this.name);
   var self = this;
-  Object.keys(this.subscribers).forEach(function(subscriber) {
-    var client = self.clientGet(subscriber);
+  Object.keys(this.subscribers).forEach(function(clientId) {
+    var client = self.clientGet(clientId);
     if (client && client.id != except && self.subscribers[client.id].listening) {
       client.send(message);
     } else {

--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -99,14 +99,14 @@ PresenceManager.prototype.destroy = function() {
     manager.clearExpiry(userId);
   });
 
-  if(this.sentryListener) {
+  if (this.sentryListener) {
     logging.debug('#presence - remove sentry listener', this.scope);
     this.sentry.removeListener('down', this.sentryListener);
     delete this.sentryListener;
   }
 
   // Client issues a full read and then dies and destroy is called.
-  if(this.handleRedisReply) {
+  if (this.handleRedisReply) {
     this.handleRedisReply = function() {};
   }
 
@@ -136,7 +136,7 @@ PresenceManager.prototype.addClient = function(clientId, userId, userType,
 
   Persistence.persistHash(this.scope, userId + '.' + clientId, message);
 
-  if(this.policy && this.policy.maxPersistence) {
+  if (this.policy && this.policy.maxPersistence) {
     Persistence.expire(this.scope, this.policy.maxPersistence);
   }
 
@@ -166,9 +166,9 @@ PresenceManager.prototype.disconnectClient = function(clientId, callback) {
   // If there is no userid, then we've already removed the user (e.g. via a remove
   // call) or, we have not added this client to the store yet. (redis reply for
   // addClient has not come)
-  if(!userId) {
+  if (!userId) {
     var message = this.store.cacheRemove(clientId);
-    if(!message) {
+    if (!message) {
       // This is possible if multiple servers are expiring a fallen server's clients
       logging.warn('#presence - no userId/userType found for', clientId,
                                     'in store, userId:', userId, this.scope);
@@ -220,8 +220,8 @@ PresenceManager.prototype.processRedisEntry = function(message, callback) {
   logging.debug('#presence - processRedisEntry:', message, this.scope);
   callback = callback || function() {};
 
-  if(this.isOnline(message)) {
-    if(!message.sentry) {
+  if (this.isOnline(message)) {
+    if (!message.sentry) {
       logging.info('#presence - #autopub - received online message without sentry',
                                                               message, this.scope);
       message.sentry = userId + '.' + clientId;
@@ -230,7 +230,7 @@ PresenceManager.prototype.processRedisEntry = function(message, callback) {
       sentry.publishKeepAlive({ name: message.sentry, save: false });
     }
 
-    if(sentry.isValid(message.sentry)) {
+    if (sentry.isValid(message.sentry)) {
       logging.debug('#presence - processRedisEntry: sentry.isValid true',
                                               message.sentry, this.scope);
       manager.clearExpiry(userId);
@@ -246,7 +246,7 @@ PresenceManager.prototype.processRedisEntry = function(message, callback) {
     }
     callback();
   } else {
-    if(this.isExpired(message)) {
+    if (this.isExpired(message)) {
       logging.info('#autopub - received online message - expired', message,
                                                                 this.scope);
 
@@ -272,7 +272,7 @@ PresenceManager.prototype.handleOffline = function(clientId, userId, userType, e
   // Only if explicit present and false.
   // When user has an expiry timer running, then don't force remove yet
   // Remove user after 15 seconds when no other clients exist
-  if(explicit === false || this.isUserExpiring(userId)) {
+  if (explicit === false || this.isUserExpiring(userId)) {
     this.store.removeClient(clientId, message);
     this.setupExpiry(userId, userType);
   } else {
@@ -286,7 +286,7 @@ PresenceManager.prototype.isUserExpiring = function(userId) {
 };
 
 PresenceManager.prototype.clearExpiry = function(userId) {
-  if(this.expiryTimers[userId]) {
+  if (this.expiryTimers[userId]) {
     logging.info('#presence - clear user expiry timeout:', userId, this.scope);
     clearTimeout(this.expiryTimers[userId]);
     delete this.expiryTimers[userId];
@@ -295,7 +295,7 @@ PresenceManager.prototype.clearExpiry = function(userId) {
 PresenceManager.prototype.setupExpiry = function(userId, userType) {
   this.clearExpiry(userId);
 
-  if(this.store.userExists(userId)) {
+  if (this.store.userExists(userId)) {
     logging.info('#presence - user expiry setup for', userId, this.scope);
     this.expiryTimers[userId] = setTimeout(this.expireUser.bind(this, userId, userType),
                                               this.policy.userExpirySeconds * 1000);
@@ -318,7 +318,7 @@ PresenceManager.prototype.fullRead = function(callback) {
 
   this.handleRedisReply = function(replies) {
     logging.debug('#presence - fullRead replies', self.scope, replies);
-    if(!replies) {
+    if (!replies) {
       if (callback) callback(self.getOnline());
       return;
     }
@@ -326,7 +326,7 @@ PresenceManager.prototype.fullRead = function(callback) {
     var count = 0, keys = Object.keys(replies);
     var completed = function() {
       count++;
-      if(count == keys.length) {
+      if (count == keys.length) {
         if (callback) callback(self.getOnline());
       }
     };

--- a/core/lib/resources/presence/presence_store.js
+++ b/core/lib/resources/presence/presence_store.js
@@ -10,7 +10,7 @@ function PresenceStore(scope) {
 
 require('util').inherits(PresenceStore, require('events').EventEmitter);
 
-//cache the client data without adding
+// Cache the client data without adding
 PresenceStore.prototype.cacheAdd = function(clientId, data) {
   this.cache[clientId] = data;
 };
@@ -51,15 +51,16 @@ PresenceStore.prototype.remove = function(clientId, userId, data) {
   logging.debug('#presence - store.remove', userId, clientId, data, this.scope);
   this.cacheRemove(clientId);
 
+  // When non-existent, return
   if(!this.map[userId] || !this.map[userId][clientId]) {
-    return; //inexistant, return
+    return;
   }
 
   events.push('client_removed');
   delete this.map[userId][clientId];
   delete this.clientUserMap[clientId];
 
-  //Empty user
+  // Empty user
   if(Object.keys(this.map[userId]).length === 0) {
     events.push('user_removed');
     delete this.map[userId];
@@ -75,13 +76,18 @@ PresenceStore.prototype.remove = function(clientId, userId, data) {
 PresenceStore.prototype.removeClient = function(clientId, data) {
   var userId = this.clientUserMap[clientId];
   this.cacheRemove(clientId);
+
+  // When non-existent, return
   if(!userId) {
-    logging.warn('#presence - store.removeClient: cannot find data for', clientId, this.scope);
-    return; //inexistant, return
+    logging.warn('#presence - store.removeClient: cannot find data for',
+                                                      clientId, this.scope);
+    return;
   }
+
   logging.debug('#presence - store.removeClient', userId, clientId, data, this.scope);
   delete this.map[userId][clientId];
   delete this.clientUserMap[clientId];
+
   logging.debug('#presence - store.emit', 'client_removed', data, this.scope);
   this.emit('client_removed', data);
 };

--- a/core/lib/resources/presence/presence_store.js
+++ b/core/lib/resources/presence/presence_store.js
@@ -27,13 +27,13 @@ PresenceStore.prototype.add = function(clientId, userId, userType, data) {
   logging.debug('#presence - store.add', userId, clientId, data, this.scope);
   this.cacheRemove(clientId);
 
-  if(!this.map[userId]) {
+  if (!this.map[userId]) {
     events.push('user_added');
     this.map[userId] = {};
     this.userTypes[userId] = userType;
   }
 
-  if(!this.map[userId][clientId]) {
+  if (!this.map[userId][clientId]) {
     events.push('client_added');
     this.map[userId][clientId] = data;
     this.clientUserMap[clientId] = userId;
@@ -52,7 +52,7 @@ PresenceStore.prototype.remove = function(clientId, userId, data) {
   this.cacheRemove(clientId);
 
   // When non-existent, return
-  if(!this.map[userId] || !this.map[userId][clientId]) {
+  if (!this.map[userId] || !this.map[userId][clientId]) {
     return;
   }
 
@@ -61,7 +61,7 @@ PresenceStore.prototype.remove = function(clientId, userId, data) {
   delete this.clientUserMap[clientId];
 
   // Empty user
-  if(Object.keys(this.map[userId]).length === 0) {
+  if (Object.keys(this.map[userId]).length === 0) {
     events.push('user_removed');
     delete this.map[userId];
     delete this.userTypes[userId];
@@ -78,7 +78,7 @@ PresenceStore.prototype.removeClient = function(clientId, data) {
   this.cacheRemove(clientId);
 
   // When non-existent, return
-  if(!userId) {
+  if (!userId) {
     logging.warn('#presence - store.removeClient: cannot find data for',
                                                       clientId, this.scope);
     return;
@@ -93,7 +93,7 @@ PresenceStore.prototype.removeClient = function(clientId, data) {
 };
 
 PresenceStore.prototype.removeUserIfEmpty = function(userId, data) {
-  if(this.userExists(userId) && this.userEmpty(userId)) {
+  if (this.userExists(userId) && this.userEmpty(userId)) {
     logging.debug('#presence - store.removeUserIfEmpty', userId, data, this.scope);
     delete this.map[userId];
     delete this.userTypes[userId];
@@ -122,13 +122,13 @@ PresenceStore.prototype.forEachClient = function(callback) {
   var store = this;
   this.users().forEach(function(userId) {
     store.clients(userId).forEach(function(clientId) {
-      if(callback) callback(userId, clientId, store.get(clientId, userId));
+      if (callback) callback(userId, clientId, store.get(clientId, userId));
     });
   });
 };
 
 PresenceStore.prototype.userEmpty = function(userId) {
-  if(this.map[userId] &&
+  if (this.map[userId] &&
      Object.keys(this.map[userId]).length === 0) {
     return true;
   }

--- a/core/lib/resources/presence/presence_store.js
+++ b/core/lib/resources/presence/presence_store.js
@@ -128,11 +128,7 @@ PresenceStore.prototype.forEachClient = function(callback) {
 };
 
 PresenceStore.prototype.userEmpty = function(userId) {
-  if (this.map[userId] &&
-     Object.keys(this.map[userId]).length === 0) {
-    return true;
-  }
-  return false;
+  return !!(this.map[userId] && Object.keys(this.map[userId]).length === 0);
 };
 
 PresenceStore.prototype.userTypeOf = function(userId) {

--- a/core/lib/resources/presence/sentry.js
+++ b/core/lib/resources/presence/sentry.js
@@ -19,16 +19,16 @@ require('util').inherits(Sentry, require('events').EventEmitter);
 
 Sentry.prototype._listen = function() {
   var self = this;
-  if(!this.listener) {
+  if (!this.listener) {
     this.listener = function(channel, m) {
-      if(channel != Sentry.channel) {
+      if (channel != Sentry.channel) {
         return;
       }
       self._save(parse(m));
     };
     Persistence.pubsub().on('message', this.listener);
   }
-  if(!this.subscribed) {
+  if (!this.subscribed) {
     this.subscribed = true;
     Persistence.pubsub().subscribe(Sentry.channel);
   }
@@ -36,7 +36,7 @@ Sentry.prototype._listen = function() {
 
 
 Sentry.prototype._save = function(message) {
-  if(message && message.name) {
+  if (message && message.name) {
     logging.debug('#presence - sentry.save', message.name,
                   (message.expiration - Date.now()) + '/' + Sentry.expiry);
     this.sentries[message.name] = message;
@@ -44,7 +44,7 @@ Sentry.prototype._save = function(message) {
 };
 
 Sentry.prototype._sentryDown = function(name) {
-  if(!this.isValid(name)) {
+  if (!this.isValid(name)) {
 
     // Cleanup
     Persistence.deleteHash(Sentry.channel, name);
@@ -73,13 +73,13 @@ Sentry.prototype.loadAll = function(callback) {
       sentries[name] = replies[name];
 
       // Cleanup
-      if(!self.isValid(name)) {
+      if (!self.isValid(name)) {
         Persistence.deleteHash(Sentry.channel, name);
         delete sentries[name];
       }
     });
 
-    if(callback) callback();
+    if (callback) callback();
   });
 };
 
@@ -106,7 +106,7 @@ Sentry.prototype.publishKeepAlive = function(options) {
   this.sentries[name] = message;
 
   // Specific check
-  if(options.save === false) return;
+  if (options.save === false) return;
 
   Persistence.persistHash(Sentry.channel, this.name, message);
   Persistence.publish(Sentry.channel, message);
@@ -115,7 +115,7 @@ Sentry.prototype.publishKeepAlive = function(options) {
 Sentry.prototype.start = function(callback) {
   var sentries = this.sentries;
   var self = this;
-  if(this.timer) {
+  if (this.timer) {
     return;
   }
   logging.info('#presence - #sentry - starting', this.name);
@@ -127,13 +127,13 @@ Sentry.prototype.start = function(callback) {
 
 Sentry.prototype.stop = function() {
   logging.info('#presence - #sentry stopping', this.name);
-  if(this.timer) {
+  if (this.timer) {
     clearTimeout(this.timer);
     delete this.timer;
   }
   Persistence.pubsub().unsubscribe(Sentry.channel);
   delete this.subscribed;
-  if(this.listener) {
+  if (this.listener) {
     Persistence.pubsub().removeListener('message', this.listener);
     delete this.listener;
   }
@@ -145,7 +145,7 @@ Sentry.prototype.isValid = function(name) {
   var valid = (message && message.expiration && (message.expiration >= Date.now()));
   var expiration = (message && message.expiration && (message.expiration - Date.now()));
 
-  if(!valid)
+  if (!valid)
     logging.debug('#presence - #sentry isValid', name, valid,
                   (expiration) ? expiration + '/' + Sentry.expiry : 'not-present');
   return valid;

--- a/core/lib/resources/status.js
+++ b/core/lib/resources/status.js
@@ -4,7 +4,7 @@ var Resource = require('../resource.js'),
 
 var default_options = {
   policy: {
-    maxPersistence: 12 * 60 * 60 // 12 hours in seconds
+    maxPersistence: 12 * 60 * 60            // 12 hours in seconds
   }
 };
 
@@ -15,7 +15,7 @@ function Status(name, parent, options) {
 Status.prototype = new Resource();
 Status.prototype.type = 'status';
 
-// get status
+// Get status
 Status.prototype.get = function(client) {
   var name = this.name;
   logger.debug('#status - get', this.name, (client && client.id));

--- a/core/lib/resources/status.js
+++ b/core/lib/resources/status.js
@@ -42,7 +42,7 @@ Status.prototype.set = function(client, message) {
 
 Status.prototype._set = function(scope, message, policy, callback) {
   Persistence.persistHash(scope, message.key, message.value);
-  if(policy && policy.maxPersistence) {
+  if (policy && policy.maxPersistence) {
     Persistence.expire(scope, policy.maxPersistence);
   } else {
     logger.warn('resource created without ttl :', scope);

--- a/core/lib/resources/stream/index.js
+++ b/core/lib/resources/stream/index.js
@@ -37,13 +37,13 @@ Stream.prototype._subscribe = function(client, message) {
       from = message.options && message.options.from,
       sub = this.subscriberState.get(client.id);
 
-  if(typeof from === 'undefined' || from < 0) {
+  if (typeof from === 'undefined' || from < 0) {
     return;
   }
 
   sub.startSubscribing(from);
   this._get(from, function(error, values) {
-    if(error) {
+    if (error) {
       var syncError = self._getSyncError(from);
       syncError.op = 'push';
       client.send(syncError);
@@ -70,7 +70,7 @@ Stream.prototype.get = function(client, message) {
   logging.debug('#stream - get', this.name,'from: '+from, (client && client.id));
 
   this._get(from, function(error, values) {
-    if(error) {
+    if (error) {
       var syncError = stream._getSyncError(from);
       syncError.op = 'get';
       syncError.value = [];
@@ -112,7 +112,7 @@ Stream.prototype.push = function(client, message) {
 
 
   this.list.push(m, function(error, stamped) {
-    if(error) {
+    if (error) {
       console.log(error);
       logging.error(error);
       return;
@@ -136,7 +136,7 @@ Stream.prototype.redisIn = function(data) {
     var client = self.clientGet(subscriber);
     if (client && client.send) {
       var sub = self.subscriberState.get(client.id);
-      if(sub && sub.sendable(data)) {
+      if (sub && sub.sendable(data)) {
         client.send(data);
         sub.sent = data.id;
       }

--- a/core/lib/resources/stream/index.js
+++ b/core/lib/resources/stream/index.js
@@ -132,8 +132,8 @@ Stream.prototype.sync = function(client, message) {
 Stream.prototype.redisIn = function(data) {
   var self = this;
   logging.info('#'+this.type, '- incoming from #redis', this.name, data, 'subs:', Object.keys(this.subscribers).length );
-  Object.keys(this.subscribers).forEach(function(subscriber) {
-    var client = self.clientGet(subscriber);
+  Object.keys(this.subscribers).forEach(function(clientId) {
+    var client = self.clientGet(clientId);
     if (client && client.send) {
       var sub = self.subscriberState.get(client.id);
       if (sub && sub.sendable(data)) {

--- a/core/lib/resources/stream/index.js
+++ b/core/lib/resources/stream/index.js
@@ -5,7 +5,7 @@ var Resource = require('../../resource.js'),
 
 var default_options = {
   policy: {
-    maxPersistence: 7 * 24 * 60 * 60, // 1 week in seconds
+    maxPersistence: 7 * 24 * 60 * 60,         // 1 week in seconds
     maxLength: 100000
   }
 };
@@ -133,7 +133,7 @@ Stream.prototype.redisIn = function(data) {
   var self = this;
   logging.info('#'+this.type, '- incoming from #redis', this.name, data, 'subs:', Object.keys(this.subscribers).length );
   Object.keys(this.subscribers).forEach(function(subscriber) {
-    var client = self.parent.server.clients[subscriber];
+    var client = self.clientGet(subscriber);
     if (client && client.send) {
       var sub = self.subscriberState.get(client.id);
       if(sub && sub.sendable(data)) {
@@ -142,7 +142,8 @@ Stream.prototype.redisIn = function(data) {
       }
     }
   });
-  //someone released the lock, wake up
+
+  // Someone released the lock, wake up
   this.list.unblock();
 };
 

--- a/core/lib/resources/stream/subscriber_state.js
+++ b/core/lib/resources/stream/subscriber_state.js
@@ -22,7 +22,7 @@ function SubscriberState() {
 }
 
 SubscriberState.prototype.get = function(clientId) {
-  if(!this.subscribers[clientId]) {
+  if (!this.subscribers[clientId]) {
     this.subscribers[clientId] = new StreamSubscriber(clientId);
   }
   return this.subscribers[clientId];

--- a/core/lib/type.js
+++ b/core/lib/type.js
@@ -31,7 +31,8 @@ function getByExpression(name) {
       definition = Types[i];
       expression = definition.expression || definition.expr;
       if (!expression) {
-        logger.error('#type - there is a type definition without an expression.', i, definition.name);
+        logger.error('#type - there is a type definition without an expression.',
+                                                              i, definition.name);
         continue;
       }
 
@@ -46,7 +47,7 @@ function getByExpression(name) {
 
 module.exports = {
   getByExpression: getByExpression,
-  // deprecated
+  // Deprecated
   register: function(name, type) {
     logger.debug('#type - register', type);
     Types.unshift(type);

--- a/core/lib/type.js
+++ b/core/lib/type.js
@@ -36,7 +36,7 @@ function getByExpression(name) {
         continue;
       }
 
-      if(expression.test && expression.test(name) || expression === name) {
+      if (expression.test && expression.test(name) || expression === name) {
         logger.debug('#type - found', name);
         return definition;
       }

--- a/sample/index.html
+++ b/sample/index.html
@@ -75,7 +75,7 @@ RadarClient.configure({
     <div id="messages"></div>
 
     <input type="text" id="send" onkeypress="e = event;
-      if(e.which == 13) {
+      if (e.which == 13) {
         e.preventDefault();
         RadarClient.message('chat/foo/messages').publish(this.value);
         this.value = '';

--- a/sample/views.js
+++ b/sample/views.js
@@ -17,9 +17,9 @@ OnlineList.prototype.render = function() {
   this.el || (this.el = document.getElementById(this.elId));
   var str = '';
   for(var userId in model.online) {
-    if(!model.online.hasOwnProperty(userId)) continue;
+    if (!model.online.hasOwnProperty(userId)) continue;
     str += '<li><span class="badge';
-    if(model.online[userId]) {
+    if (model.online[userId]) {
       str += ' badge-success';
     }
     str += '"></span> '+userId+'</li>';
@@ -57,9 +57,9 @@ model = {
 };
 
 function onlineUpdate(message) {
-  if(message.op != 'online' && message.op != 'offline') return;
+  if (message.op != 'online' && message.op != 'offline') return;
   for(var userId in message.value) {
-    if(!message.value.hasOwnProperty(userId)) continue;
+    if (!message.value.hasOwnProperty(userId)) continue;
     model.online[userId] = !!(message.op == 'online');
   }
 }

--- a/server.js
+++ b/server.js
@@ -4,9 +4,7 @@ var http = require('http'),
     Api = require('./api/api.js'),
     Minilog = require('minilog');
 
-var server;
-
-// configure log output
+// Configure log output
 Minilog.pipe(Minilog.suggest.deny(/.*/, (process.env.radar_log ? process.env.radar_log : 'debug')))
     .pipe(Minilog.backends.nodeConsole.formatWithStack)
     .pipe(Minilog.backends.nodeConsole);
@@ -17,7 +15,8 @@ function p404(req, res){
   res.end('404 Not Found');
 }
 
-server = http.createServer(p404);
+var server = http.createServer(p404);
+
 // Radar API
 Api.attach(server);
 

--- a/server/server.js
+++ b/server/server.js
@@ -104,7 +104,7 @@ Server.prototype.handlePubSubMessage = function(name, data) {
     this.resources[name].redisIn(data);
   } else {
     // Don't log sentry channel pub messages
-    if(name == Core.Presence.Sentry.channel) return;
+    if (name == Core.Presence.Sentry.channel) return;
 
     logging.warn('#redis - message not handled', name, data);
   }
@@ -115,7 +115,7 @@ Server.prototype.message = function(client, data) {
   var message = parseJSON(data);
 
   // Format check
-  if(!message || !message.op || !message.to) {
+  if (!message || !message.op || !message.to) {
     logging.warn('#client.message - rejected', (client && client.id), data);
     return;
   }
@@ -128,10 +128,10 @@ Server.prototype.message = function(client, data) {
   var resource = this.resourceGet(message.to);
 
   if (resource && resource.authorize(message, client, data)) {
-    if(!this.subs[resource.name]) {
+    if (!this.subs[resource.name]) {
       logging.info('#redis - subscribe', resource.name, (client && client.id));
       this.subscriber.subscribe(resource.name, function(err) {
-        if(err) {
+        if (err) {
           logging.error('#redis - subscribe failed', resource.name,
                                           (client && client.id), err);
         } else {
@@ -169,7 +169,7 @@ Server.prototype.resourceGet = function(name) {
 
 // Destroy empty resource
 Server.prototype.destroyResource = function(name) {
-  if(this.resources[name]) {
+  if (this.resources[name]) {
     this.resources[name].destroy();
   }
   delete this.resources[name];

--- a/server/server.js
+++ b/server/server.js
@@ -46,7 +46,8 @@ Server.prototype._setup = function(http_server, configuration) {
     engine = configuration.engineio.module;
     engineConf = configuration.engineio.conf;
 
-    this.engineioPath = configuration.engineio.conf ? configuration.engineio.conf.path : 'default';
+    this.engineioPath = configuration.engineio.conf ?
+                configuration.engineio.conf.path : 'default';
   }
 
   this.server = engine.attach(http_server, engineConf);
@@ -60,13 +61,13 @@ Server.prototype.onClientConnection = function(client) {
   var self = this;
   var oldSend = client.send;
 
-  // always send data as json
+  // Always send data as json
   client.send = function(data) {
     logging.info('#client - sending data', client.id, data);
     oldSend.call(client, JSON.stringify(data));
   };
 
-  // event: client connected
+  // Event: client connected
   logging.info('#client - connect', client.id);
 
   client.send({
@@ -79,7 +80,7 @@ Server.prototype.onClientConnection = function(client) {
   });
 
   client.on('close', function() {
-    // event: client disconnected
+    // Event: client disconnected
     logging.info('#client - disconnect', client.id);
 
     Object.keys(self.resources).forEach(function(name) {
@@ -102,7 +103,9 @@ Server.prototype.handlePubSubMessage = function(name, data) {
 
     this.resources[name].redisIn(data);
   } else {
-    if(name == Core.Presence.Sentry.channel) return; //limit unwanted logs
+    // Don't log sentry channel pub messages
+    if(name == Core.Presence.Sentry.channel) return;
+
     logging.warn('#redis - message not handled', name, data);
   }
 };
@@ -111,7 +114,7 @@ Server.prototype.handlePubSubMessage = function(name, data) {
 Server.prototype.message = function(client, data) {
   var message = parseJSON(data);
 
-  // format check
+  // Format check
   if(!message || !message.op || !message.to) {
     logging.warn('#client.message - rejected', (client && client.id), data);
     return;
@@ -129,9 +132,11 @@ Server.prototype.message = function(client, data) {
       logging.info('#redis - subscribe', resource.name, (client && client.id));
       this.subscriber.subscribe(resource.name, function(err) {
         if(err) {
-          logging.error('#redis - subscribe failed', resource.name, (client && client.id), err);
+          logging.error('#redis - subscribe failed', resource.name,
+                                          (client && client.id), err);
         } else {
-          logging.info('#redis - subscribe successful', resource.name, (client && client.id));
+          logging.info('#redis - subscribe successful', resource.name,
+                                          (client && client.id));
         }
       });
       this.subs[resource.name] = true;

--- a/tests/client.auth.test.js
+++ b/tests/client.auth.test.js
@@ -44,7 +44,7 @@ describe('auth test', function() {
     });
 
     it('publish fails, emits err and is not persisted', function(done) {
-      //cache policy true for this type
+      // Cache policy true for this type
       client.on('err', function(message) {
         assert.ok(message.origin);
         assert.equal(message.origin.op, 'publish');
@@ -74,7 +74,7 @@ describe('auth test', function() {
         assert.ok(false);
       });
 
-      //Messages of the form 'disabled' are disabled
+      // Messages of the form 'disabled' are disabled
       client.message('enabled').subscribe().publish(originalMessage);
     });
   });

--- a/tests/client.message.test.js
+++ b/tests/client.message.test.js
@@ -56,7 +56,7 @@ describe('When using message list resources:', function() {
       });
     });
 
-    // sending a message should only send to each subscriber, but only once
+    // Sending a message should only send to each subscriber, but only once
     it('should receive a message only once per subscriber', function(done) {
       var message = { state: 'test1'};
 
@@ -86,8 +86,8 @@ describe('When using message list resources:', function() {
     });
 
     it('should only receive message when subscribed', function(done) {
-      //send three messages, client2 will assert if it receieves any,
-      //Stop test when we receive all three at client 1
+      // Send three messages, client2 will assert if it receieves any
+      // Stop test when we receive all three at client 1
 
       var message = { state: 'test1'},
           message2 = { state: 'test2' },
@@ -109,9 +109,9 @@ describe('When using message list resources:', function() {
     });
 
     it('should not receive messages after unsubscribe', function(done) {
-      //send two messages after client2 unsubscribes,
+      // Send two messages after client2 unsubscribes,
       // client2 will assert if it receives message 2 and 3
-      //Stop test when we receive all three at client 1
+      // Stop test when we receive all three at client 1
 
       var message = { state: 'test1'};
       var message2 = { state: 'test2'};
@@ -126,7 +126,7 @@ describe('When using message list resources:', function() {
 
       client.message('test').on(function(msg) {
         if(msg.value.state == 'test3') {
-          //received third message without asserting
+          // Received third message without asserting
           done();
         }
       });

--- a/tests/client.message.test.js
+++ b/tests/client.message.test.js
@@ -68,7 +68,7 @@ describe('When using message list resources:', function() {
         assert.equal(message.state, msg.value.state);
         assert.ok( !finished[client_name] );
         finished[client_name] = true;
-        if(finished.client && finished.client2) {
+        if (finished.client && finished.client2) {
           setTimeout(done,30);
         }
       }
@@ -98,7 +98,7 @@ describe('When using message list resources:', function() {
       });
 
       client.message('test').on(function(msg) {
-        if(msg.value.state == 'test3') {
+        if (msg.value.state == 'test3') {
           done();
         }
       });
@@ -125,7 +125,7 @@ describe('When using message list resources:', function() {
       });
 
       client.message('test').on(function(msg) {
-        if(msg.value.state == 'test3') {
+        if (msg.value.state == 'test3') {
           // Received third message without asserting
           done();
         }
@@ -142,7 +142,7 @@ describe('When using message list resources:', function() {
 
       client2.message('cached_chat/1').subscribe().on(function(m) {
         received.push(m);
-        if(received.length == 4) {
+        if (received.length == 4) {
           setTimeout(verify, 50);
         }
       });
@@ -191,7 +191,7 @@ describe('When using message list resources:', function() {
       var message = { state: 'other'};
 
       client.message('test').when(function(msg) {
-        if(msg.value && msg.value.state && msg.value.state == 'other') {
+        if (msg.value && msg.value.state && msg.value.state == 'other') {
           assert.equal('message:/dev/test', msg.to);
           assert.equal('other', msg.value.state);
           done();
@@ -274,7 +274,7 @@ describe('When using message list resources:', function() {
 
       client2.message('cached_chat/1').subscribe().on(function(m) {
         written++;
-        if(written == messages.length)
+        if (written == messages.length)
           syncTest();
       });
 
@@ -285,7 +285,7 @@ describe('When using message list resources:', function() {
       function syncTest() {
         client.message('cached_chat/1').on(function(msg) {
           received.push(msg);
-          if(received.length == messages.length) {
+          if (received.length == messages.length) {
             setTimeout(function() {
               assert.equal(messages.length, received.length);
               for(var i = 0; i < received.length; i++) {

--- a/tests/client.presence.remote.test.js
+++ b/tests/client.presence.remote.test.js
@@ -33,7 +33,10 @@ describe('given a client and a server,', function() {
     p.client = { clientId: 'abc', userId: 100, userType: 2, userData: { name: 'tester' } };
     var track = Tracker.create('beforeEach', done);
     sentry.name = 'test-sentry';
-    sentry.publishKeepAlive(); //set ourselves alive
+
+    // Set ourselves alive
+    sentry.publishKeepAlive();
+
     client = common.getClient('dev', 123, 0, { name: 'tester' }, track('client 1 ready'));
     notifications = [];
   });
@@ -109,7 +112,10 @@ describe('given a client and a server,', function() {
 
       describe('from legacy servers, ', function() {
         it('should emit online if message is not expired', function(done) {
-          delete sentry.name; //remove sentry and add autopub level expiry
+
+          // Remove sentry and add autopub level expiry
+          delete sentry.name;
+
           presenceManager.stampExpiration = function(message) {
             message.at = Date.now();
           };
@@ -125,7 +131,9 @@ describe('given a client and a server,', function() {
           });
         });
         it('should ignore expired messages', function(done) {
-          delete sentry.name; //remove sentry and add autopub level expiry
+
+          // Remove sentry and add autopub level expiry
+          delete sentry.name;
           presenceManager.stampExpiration = function(message) {
             message.at = Date.now() - 5000;
           };

--- a/tests/client.presence.sentry.test.js
+++ b/tests/client.presence.sentry.test.js
@@ -23,9 +23,11 @@ describe('given a client and a server,', function() {
       m.at = Date.now();
     };
     publish_client_online(client);
-    //restore
+    // Restore
     sentry.name = 'test-sentry';
-    delete presenceManager.stampExpiration; //restore from prototype
+
+    // Restore from prototype
+    delete presenceManager.stampExpiration;
   };
 
   before(function(done) {
@@ -45,7 +47,9 @@ describe('given a client and a server,', function() {
   beforeEach(function(done) {
     p = new PresenceAssert('dev', 'test');
     p.client = { userId: 100, clientId: 'abc', userData: { name: 'tester' }, userType: 2 };
-    sentry.publishKeepAlive(); //set ourselves alive
+
+    // Set ourselves alive
+    sentry.publishKeepAlive();
     var track = Tracker.create('beforeEach', done);
     client = common.getClient('dev', 123, 0, { name: 'tester' }, track('client 1 ready'));
   });
@@ -69,11 +73,17 @@ describe('given a client and a server,', function() {
         this.timeout(8000);
         var validate = function() {
           var ts = p.times;
-          p.assert_message_sequence(['online', 'client_online', 'client_implicit_offline', 'offline']);
-          assert.ok((ts[2] - ts[1]) >= 3000, 'sentry expiry was '+(ts[2] - ts[1])); //sentry expiry = 4000
-          assert.ok((ts[2] - ts[1]) < 6000, 'sentry expiry was '+(ts[2] - ts[1])); //sentry expiry = 4000
-          assert.ok((ts[3] - ts[2]) >= 900, 'user expiry was '+(ts[3] - ts[2])); //user expiry = 1000
-          assert.ok((ts[3] - ts[2]) < 2000, 'user expiry was '+(ts[3] - ts[2])); //user expiry = 1000
+          p.assert_message_sequence(['online', 'client_online',
+                                'client_implicit_offline', 'offline']);
+
+          // sentry expiry = 4000
+          assert.ok((ts[2] - ts[1]) >= 3000, 'sentry expiry was '+(ts[2] - ts[1]));
+          // sentry expiry = 4000
+          assert.ok((ts[2] - ts[1]) < 6000, 'sentry expiry was '+(ts[2] - ts[1]));
+          // user expiry = 1000
+          assert.ok((ts[3] - ts[2]) >= 900, 'user expiry was '+(ts[3] - ts[2]));
+          // user expiry = 1000
+          assert.ok((ts[3] - ts[2]) < 2000, 'user expiry was '+(ts[3] - ts[2]));
           done();
         };
 
@@ -90,7 +100,8 @@ describe('given a client and a server,', function() {
 
         publish_client_online(p.client);
         setTimeout(function() {
-          sentry.publishKeepAlive(); //renew sentry
+          // Renew sentry
+          sentry.publishKeepAlive();
         }, 2000);
 
         p.fail_on_more_than(2);
@@ -104,16 +115,21 @@ describe('given a client and a server,', function() {
           this.timeout(8000);
           var validate = function() {
             var ts = p.times;
-            p.assert_message_sequence(['online', 'client_online', 'client_implicit_offline', 'offline']);
+            p.assert_message_sequence(['online', 'client_online',
+                                      'client_implicit_offline', 'offline']);
 
-            assert.ok((ts[2] - ts[1]) >= 3000, 'sentry expiry was '+(ts[2] - ts[1])); //sentry expiry = 4000
-            assert.ok((ts[3] - ts[2]) >= 900, 'user expiry was '+(ts[3] - ts[2])); //user expiry = 1000
-            assert.ok((ts[3] - ts[2]) >= 900, 'user expiry was '+(ts[3] - ts[2])); //user expiry = 1000
-            assert.ok((ts[3] - ts[2]) < 1900, 'user expiry was '+(ts[3] - ts[2])); //user expiry = 1000
+            // sentry expiry = 4000
+            assert.ok((ts[2] - ts[1]) >= 3000, 'sentry expiry was '+(ts[2] - ts[1]));
+            // user expiry = 1000
+            assert.ok((ts[3] - ts[2]) >= 900, 'user expiry was '+(ts[3] - ts[2]));
+            // user expiry = 1000
+            assert.ok((ts[3] - ts[2]) >= 900, 'user expiry was '+(ts[3] - ts[2]));
+            // user expiry = 1000
+            assert.ok((ts[3] - ts[2]) < 1900, 'user expiry was '+(ts[3] - ts[2]));
             done();
           };
 
-          //simulate autopub
+          // Simulate autopub
           publish_autopub(p.client);
 
           p.once(4, validate);
@@ -126,11 +142,11 @@ describe('given a client and a server,', function() {
             done();
           };
 
-          //simulate autopub
+          // Simulate autopub
           publish_autopub(p.client);
 
           setTimeout(function() {
-            //send an autopub message
+            // Send an autopub message
             publish_autopub(p.client);
           }, 2000);
 

--- a/tests/client.presence.test.js
+++ b/tests/client.presence.test.js
@@ -212,7 +212,7 @@ describe('given two clients and a presence resource', function() {
         var count = 8;
 
         var toggle = function(index) {
-          if(index % 2 === 0) {
+          if (index % 2 === 0) {
             expected = expected.concat(['online', 'client_online']);
             client.presence('test').set('online');
           } else {

--- a/tests/client.presence.test.js
+++ b/tests/client.presence.test.js
@@ -46,7 +46,7 @@ describe('given two clients and a presence resource', function() {
 
       p.fail_on_more_than(4);
       p.once(4, function() {
-        // ensure that no more messages come
+        // Ensure that no more messages come
         setTimeout(function() {
           p.for_client(client2).assert_message_sequence([
             'online', 'client_online', 'client_explicit_offline', 'offline'
@@ -62,7 +62,7 @@ describe('given two clients and a presence resource', function() {
 
       p.fail_on_more_than(2);
       p.on(2, function() {
-        // online and client_online
+        // Online and client_online
         p.for_client(client2).assert_message_sequence(
           [ 'online', 'client_online' ]
         );
@@ -77,12 +77,12 @@ describe('given two clients and a presence resource', function() {
 
     describe('with a client subscribed', function() {
       it('should receive presence notifications if a client comes online', function(done) {
-        // subscribe online with client 2
+        // Subscribe online with client 2
         client2.presence('test').on(p.notify).subscribe(function() {
-          // set client 1 to online
+          // Set client 1 to online
           client.presence('test').set('online', function() {
             client2.presence('test').get(function(message) {
-              // should show client 1 as online
+              // Should show client 1 as online
               p.for_online_clients(client).assert_get_response(message);
               p.for_client(client).assert_message_sequence(
                 [ 'online', 'client_online' ]
@@ -95,7 +95,7 @@ describe('given two clients and a presence resource', function() {
 
       it('should not receive any notification if an offline client unsubscribes', function(done) {
         p.fail_on_any_message();
-        // subscribe online with client 2
+        // Subscribe online with client 2
         client2.presence('test').on(p.notify).subscribe(function() {
           // client 1 disconnect
           client.presence('test').unsubscribe();
@@ -104,7 +104,7 @@ describe('given two clients and a presence resource', function() {
       });
 
       it('should not receive notifications after we unsubscribe', function(done) {
-        // subscribe online with client 2
+        // Subscribe online with client 2
         client2.presence('test').on(p.notify).subscribe(function() {
           client.presence('test').set('online');
         });
@@ -170,19 +170,21 @@ describe('given two clients and a presence resource', function() {
         client.presence('test').set('online', function() {
           var presence = client2.presence('test').sync({ version: 2 }, function(message) {
             p.for_online_clients(client).assert_sync_v2_response(message);
+
+            // Reread after a while
             setTimeout(function() {
               presence.get({ version: 2 }, function(message) {
                 p.for_online_clients(client).assert_get_v2_response(message);
                 done();
               });
-            }, 1500); //reread after a while
+            }, 1500);
           });
         });
       });
 
       it('should not send notifications for a set(offline) if already offline', function(done) {
         p.fail_on_any_message();
-        // subscribe online with client 2
+        // Subscribe online with client 2
         client2.presence('test').on(p.notify).subscribe(function() {
           client.presence('test').set('offline');
           setTimeout(done, 50);
@@ -190,7 +192,7 @@ describe('given two clients and a presence resource', function() {
       });
 
       it('should send online notification only once for multiple set(online)', function(done) {
-        // subscribe online with client 2
+        // Subscribe online with client 2
         client2.presence('test').on(p.notify)
           .subscribe(function() {
             client.presence('test').set('online');
@@ -341,12 +343,12 @@ describe('given two clients and a presence resource', function() {
     it('can be called multiple times without changing the result', function(done) {
       this.timeout(6000);
       client2.presence('test').on(p.notify).subscribe(function() {
-        // set client 1 to online
+        // Set client 1 to online
         client.presence('test').set('online', function() {
 
           var foo = setInterval(function() {
             client2.presence('test').get(function(message) {
-              // both should show client 1 as online
+              // Both should show client 1 as online
               p.for_online_clients(client).assert_get_response(message);
               p.for_client(client).assert_message_sequence(
                 ['online', 'client_online']
@@ -375,12 +377,12 @@ describe('given two clients and a presence resource', function() {
     });
 
     it('should respond correctly when using via v2 API (with userData)', function(done) {
-      // not supported in v1 api because the result.op == "online" which is handled by the message
-      // listener but not by the sync() callback
+      // Not supported in v1 api because the result.op == "online" which is handled
+      // by the message listener but not by the sync() callback
 
       client.presence('test').set('online', function() {
         client.presence('test').sync({ version: 2 }, function(message) {
-          // sync is implemented as subscribe + get, hence the return op is "get"
+          // Sync is implemented as subscribe + get, hence the return op is "get"
           p.for_online_clients(client).assert_sync_v2_response(message);
           done();
         });
@@ -388,12 +390,12 @@ describe('given two clients and a presence resource', function() {
     });
 
     it('should respond correctly when using via v2 API (without userData)', function(done) {
-      // not supported in v1 api because the result.op == "online" which is handled by the message
-      // listener but not by the sync() callback
+      // Not supported in v1 api because the result.op == "online" which is handled
+      // by the message listener but not by the sync() callback
 
       client3.presence('test').set('online', function() {
         client3.presence('test').sync({ version: 2 }, function(message) {
-          // sync is implemented as subscribe + get, hence the return op is "get"
+          // Sync is implemented as subscribe + get, hence the return op is "get"
           p.for_online_clients(client3).assert_sync_v2_response(message);
           done();
         });
@@ -402,7 +404,7 @@ describe('given two clients and a presence resource', function() {
 
     it('should also subscribe to that resource', function(done) {
       client.presence('test').on(p.notify).sync(function(message) {
-        // wait for sync to complete
+        // Wait for sync to complete
         p.for_online_clients().assert_sync_response(message);
         client.presence('test').set('online');
       });
@@ -417,15 +419,15 @@ describe('given two clients and a presence resource', function() {
     it('can be called multiple times without changing the result', function(done) {
       this.timeout(6000);
       client2.presence('test').on(p.notify).subscribe(function() {
-        // set client 1 to online
+        // Set client 1 to online
         client.presence('test').set('online', function() {
 
           var foo = setInterval(function() {
             client2.presence('test').sync(function(message) {
-              // both should show client 1 as online
+              // Both should show client 1 as online
               p.for_online_clients(client).assert_sync_response(message);
 
-              //Not more than 2 notifications ever
+              // Not more than 2 notifications ever
               p.for_client(client).assert_message_sequence(
                 ['online', 'client_online']);
             });
@@ -448,7 +450,7 @@ describe('given two clients and a presence resource', function() {
         // Hack a bit so that socketId is saved
         var clientId = client2.currentClientId();
         client2.currentClientId = function() { return clientId; };
-        //disconnect, causing a request timeout or socket close
+        // Disconnect, causing a request timeout or socket close
         client2.manager.close();
       },10);
     });
@@ -483,7 +485,8 @@ describe('given two clients and a presence resource', function() {
           p.for_online_clients(client).assert_get_response(message);
         });
         p.on(4, function() {
-          assert.ok(Date.now() - time > 950); //timeout is 1 second
+          // Timeout is 1 second
+          assert.ok(Date.now() - time > 950);
           p.for_client(client).assert_message_sequence([
             'online', 'client_online', 'client_implicit_offline', 'offline'
           ]);

--- a/tests/client.reconnect.test.js
+++ b/tests/client.reconnect.test.js
@@ -77,7 +77,7 @@ describe('When radar server restarts', function() {
 
       var presence_done = tracker('presence updated');
       client.presence('restore').on(function (message) {
-        if(message.op === 'online') {
+        if (message.op === 'online') {
           assert.equal(message.to, 'presence:/test/restore');
           presence_done();
         }
@@ -122,7 +122,7 @@ describe('When radar server restarts', function() {
       client2.alloc('test', function() {
         client.message('foo').on(function(msg) {
           messages.push(msg);
-          if(messages.length == 2) {
+          if (messages.length == 2) {
             // When we have enough, wait a while and check
             setTimeout(verifySubscriptions, 100);
           }

--- a/tests/client.reconnect.test.js
+++ b/tests/client.reconnect.test.js
@@ -12,9 +12,9 @@ describe('When radar server restarts', function() {
   var client, client2;
 
   before(function(done) {
-    //FIXME: Need to fix transport.close in radar_client, probably not needed in 0.7.4
-    //Backoff.durations = [ 500, 600, 700, 800, 900 ]; //make them quicker
-    //Backoff.fallback = 200;
+    // FIXME: Need to fix transport.close in radar_client, probably not needed in 0.7.4
+    // Backoff.durations = [ 500, 600, 700, 800, 900 ]; //make them quicker
+    // Backoff.fallback = 200;
     radar = common.spawnRadar();
     radar.sendCommand('start', common.configuration, done);
   });
@@ -123,7 +123,7 @@ describe('When radar server restarts', function() {
         client.message('foo').on(function(msg) {
           messages.push(msg);
           if(messages.length == 2) {
-            //when we have enough, wait a while and check
+            // When we have enough, wait a while and check
             setTimeout(verifySubscriptions, 100);
           }
         }).sync();

--- a/tests/client.status.test.js
+++ b/tests/client.status.test.js
@@ -50,7 +50,7 @@ describe('When using status resources', function() {
       });
     });
 
-    // sending a message should only send to each subscriber, but only once
+    // Sending a message should only send to each subscriber, but only once
     it('should receive a message only once per subscriber', function(done) {
       var message  = { state: 'test1'},
           finished = {};
@@ -88,8 +88,8 @@ describe('When using status resources', function() {
     });
 
     it('should only receive message when subscribed', function(done) {
-      //send three messages, client2 will assert if it receieves any,
-      //Stop test when we receive all three at client 1
+      // Send three messages, client2 will assert if it receieves any
+      // Stop test when we receive all three at client 1
 
       var message = { state: 'test1'},
           message2 = { state: 'test2' },
@@ -111,9 +111,9 @@ describe('When using status resources', function() {
     });
 
     it('should not receive messages after unsubscribe', function(done) {
-      //send two messages after client2 unsubscribes,
+      // Send two messages after client2 unsubscribes,
       // client2 will assert if it receives message 2 and 3
-      //Stop test when we receive all three at client 1
+      // Stop test when we receive all three at client 1
 
       var message = { state: 'test1'};
       var message2 = { state: 'test2'};
@@ -128,7 +128,7 @@ describe('When using status resources', function() {
 
       client.status('test').on(function(msg) {
         if(msg.value.state == 'test3') {
-          //received third message without asserting
+          // Received third message without asserting
           done();
         }
       });
@@ -216,12 +216,12 @@ describe('When using status resources', function() {
 
   describe('sync', function() {
     it('calls back with the value, does not notify', function(done) {
-      //Make sure redis message has reflected.
+      // Make sure redis message has reflected.
       client2.status('test').subscribe().set('foo').once(function() {
         client.status('test').on(function(message) {
           assert.ok(false);
         }).sync(function(message) {
-          // sync is implemented as subscribe + get, hence the return op is "get"
+          // Sync is implemented as subscribe + get, hence the return op is "get"
           assert.equal('get', message.op);
           assert.deepEqual({ 246: 'foo'}, message.value);
           setTimeout(done,50);
@@ -239,7 +239,7 @@ describe('When using status resources', function() {
           assert.deepEqual(0, message.type);
           done();
         }).sync(function(message) {
-          // sync is implemented as subscribe + get, hence the return op is "get"
+          // Sync is implemented as subscribe + get, hence the return op is "get"
           assert.equal('get', message.op);
           assert.deepEqual({ 123: 'foo'}, message.value);
           client.status('test').set('bar');
@@ -249,7 +249,7 @@ describe('When using status resources', function() {
     it('can sync a String', function(done) {
       client.status('test').set('foo', function() {
         client.status('test').sync(function(message) {
-          // sync is implemented as subscribe + get, hence the return op is "get"
+          // Sync is implemented as subscribe + get, hence the return op is "get"
           assert.equal('get', message.op);
           assert.deepEqual({ 123: 'foo'}, message.value);
           done();
@@ -259,7 +259,7 @@ describe('When using status resources', function() {
     it('can sync an Object', function(done) {
       client.status('test').set({ foo: 'bar' }, function() {
         client.status('test').sync(function(message) {
-          // sync is implemented as subscribe + get, hence the return op is "get"
+          // Sync is implemented as subscribe + get, hence the return op is "get"
           assert.equal('get', message.op);
           assert.deepEqual({ 123: { foo: 'bar' } }, message.value);
           done();
@@ -268,7 +268,7 @@ describe('When using status resources', function() {
     });
     it('returns {} when not set', function(done) {
       client.status('test').sync(function(message) {
-        // sync is implemented as subscribe + get, hence the return op is "get"
+        // Sync is implemented as subscribe + get, hence the return op is "get"
         assert.equal('get', message.op);
         assert.deepEqual({}, message.value);
         done();

--- a/tests/client.status.test.js
+++ b/tests/client.status.test.js
@@ -62,7 +62,7 @@ describe('When using status resources', function() {
         assert.equal(message.state, msg.value.state);
         assert.ok( !finished[client_name] );
         finished[client_name] = true;
-        if(finished.client && finished.client2) {
+        if (finished.client && finished.client2) {
           setTimeout(done,30);
         }
       }
@@ -100,7 +100,7 @@ describe('When using status resources', function() {
       });
 
       client.status('test').on(function(msg) {
-        if(msg.value.state == 'test3') {
+        if (msg.value.state == 'test3') {
           done();
         }
       });
@@ -127,7 +127,7 @@ describe('When using status resources', function() {
       });
 
       client.status('test').on(function(msg) {
-        if(msg.value.state == 'test3') {
+        if (msg.value.state == 'test3') {
           // Received third message without asserting
           done();
         }

--- a/tests/client.stream.test.js
+++ b/tests/client.stream.test.js
@@ -62,7 +62,7 @@ describe('When using the stream resource', function() {
       function validate(msg, client_name) {
         assert.ok( !finished[client_name] );
         finished[client_name] = true;
-        if(finished.client && finished.client2) {
+        if (finished.client && finished.client2) {
           setTimeout(done,30);
         }
       }

--- a/tests/client.stream.test.js
+++ b/tests/client.stream.test.js
@@ -54,7 +54,7 @@ describe('When using the stream resource', function() {
       });
     });
 
-    // sending a message should only send to each subscriber, but only once
+    // Sending a message should only send to each subscriber, but only once
     it('should receive a message only once per subscriber', function(done) {
       var message  = { state: 'test1'},
           finished = {};
@@ -91,8 +91,8 @@ describe('When using the stream resource', function() {
     });
 
     it('should only receive message when subscribed', function(done) {
-      //send three messages, client2 will assert if it receieves any,
-      //Stop test when we receive all three at client 1
+      // Send three messages, client2 will assert if it receieves any
+      // Stop test when we receive all three at client 1
 
       var message = { state: 'test1'},
           message2 = { state: 'test2' },
@@ -118,9 +118,9 @@ describe('When using the stream resource', function() {
     });
 
     it('should not receive messages after unsubscribe', function(done) {
-      //send two messages after client2 unsubscribes,
+      // Send two messages after client2 unsubscribes,
       // client2 will assert if it receives message 2 and 3
-      //Stop test when we receive all three at client 1
+      // Stop test when we receive all three at client 1
 
       var message = { state: 'test1'};
       var message2 = { state: 'test2'};
@@ -366,7 +366,7 @@ describe('When using the stream resource', function() {
 
   describe('sync', function() {
     it('calls back with the value, does not notify', function(done) {
-      //Make sure redis message has reflected.
+      // Make sure redis message has reflected.
       client2.stream('test').subscribe().push('ticket/1', 'open', 'foo').once(function() {
         client.stream('test').on(function(message) {
           assert.ok(false);

--- a/tests/common.js
+++ b/tests/common.js
@@ -13,7 +13,7 @@ var http = require('http'),
 Sentry.expiry = 4000;
 if (process.env.verbose) {
   var Minilog = require('minilog');
-  // configure log output
+  // Configure log output
   Minilog.pipe(Minilog.suggest.deny(/.*/, (process.env.radar_log ? process.env.radar_log : 'debug')))
     .pipe(formatter)
     .pipe(Minilog.backends.nodeConsole.formatColor)

--- a/tests/common.js
+++ b/tests/common.js
@@ -25,7 +25,7 @@ if (process.env.verbose) {
     .pipe(process.stdout);
 }
 
-if(process.env.radar_connection) {
+if (process.env.radar_connection) {
   configuration.use_connection = process.env.radar_connection;
 }
 
@@ -40,8 +40,8 @@ module.exports = {
       var listener = function(message) {
         message = JSON.parse(message);
         logging.debug("message received", message, action);
-        if(message.action == action) {
-          if(callback) callback(message.error);
+        if (message.action == action) {
+          if (callback) callback(message.error);
         }
       };
       return listener;
@@ -52,7 +52,7 @@ module.exports = {
       var listener = getListener(command, function(error) {
         logging.debug("removing listener", command);
         radarProcess.removeListener('message', listener);
-        if(callback) callback(error);
+        if (callback) callback(error);
       });
 
       radarProcess.on('message', listener);
@@ -83,7 +83,7 @@ module.exports = {
 
   restartRadar: function(radar, configuration, clients, callback) {
     var tracker = Tracker.create('server restart, given clients ready', function() {
-      if(callback) setTimeout(callback,0);
+      if (callback) setTimeout(callback,0);
     });
 
     for(var i = 0; i < clients.length; i++) {
@@ -98,7 +98,7 @@ module.exports = {
   },
 
   startPersistence: function(done) {
-    if(process.env.radar_connection) {
+    if (process.env.radar_connection) {
       configuration.use_connection = process.env.radar_connection;
     }
     Persistence.setConfig(configuration);

--- a/tests/lib/assert_helper.js
+++ b/tests/lib/assert_helper.js
@@ -1,7 +1,7 @@
 var assert = require('assert'),
     EE = require('events').EventEmitter;
 
-//presence helper
+// Presence helper
 function PresenceMessage(account, name) {
   this.scope = 'presence:/'+account+'/'+name;
   this.notifications = [];
@@ -220,8 +220,8 @@ PresenceMessage.prototype.assert_get_response = function(message) {
   }, message);
 };
 
-//get v2 response:
-//{ op:"get",
+// get v2 response:
+// { op:"get",
 //  to:"presence:/<account>/<scope>",
 //  value: {
 //    <user_id>: {
@@ -233,7 +233,7 @@ PresenceMessage.prototype.assert_get_response = function(message) {
 //    },
 //   ...
 //  }
-//}
+// }
 PresenceMessage.prototype.assert_get_v2_response = function(message) {
   var value = {};
   clients = this.online_clients || [];
@@ -278,7 +278,7 @@ PresenceMessage.prototype.assert_sync_response = function(message) {
   }, message);
 };
 
-//sync v2 response: same as get v2
+// Sync v2 response: same as get v2
 PresenceMessage.prototype.assert_sync_v2_response = PresenceMessage.prototype.assert_get_v2_response;
 // ack format
 // { op: 'set/subscribe/unsubscribe',
@@ -312,7 +312,9 @@ PresenceMessage.prototype.assert_ack_for = function(type, message) {
 
   assert.deepEqual(expected, message);
   assert.ok(ackNumber > 0);
-  message.ack = ackNumber; //restore
+
+  // Restore
+  message.ack = ackNumber;
 };
 
 PresenceMessage.prototype.assert_ack_for_set_online = function(message) {
@@ -331,7 +333,7 @@ PresenceMessage.prototype.assert_ack_for_unsubscribe = function(message) {
   this.assert_ack_for('unsubscribe', message);
 };
 
-//timing of messages
+// Timing of messages
 PresenceMessage.prototype.assert_delay_between_notifications_within_range = function(i, j, low, high) {
   var delay;
   delay = this.times[j] - this.times[i];
@@ -340,7 +342,7 @@ PresenceMessage.prototype.assert_delay_between_notifications_within_range = func
 };
 
 
-//stream
+// Stream
 
 function StreamMessage(account, name) {
   this.scope = 'stream:/'+account+'/'+name;
@@ -393,7 +395,9 @@ StreamMessage.prototype.assert_ack_for = function(type, message, resource, actio
 
   assert.deepEqual(expected, message);
   assert.ok(ackNumber > 0);
-  message.ack = ackNumber; //restore
+
+  // Restore
+  message.ack = ackNumber;
 };
 
 StreamMessage.prototype.assert_ack_for_subscribe = PresenceMessage.prototype.assert_ack_for_subscribe;
@@ -491,7 +495,7 @@ StreamMessage.prototype.assert_sync_error_get_response = function(response, stat
     error: error
   }, response);
 };
-// sync is implemented as subscribe + get, hence the return op is "get"
+// Sync is implemented as subscribe + get, hence the return op is "get"
 StreamMessage.prototype.assert_sync_response = StreamMessage.prototype.assert_get_response;
 StreamMessage.prototype.fail_on_more_than = PresenceMessage.prototype.fail_on_more_than;
 module.exports.PresenceMessage = PresenceMessage;

--- a/tests/lib/assert_helper.js
+++ b/tests/lib/assert_helper.js
@@ -35,7 +35,7 @@ PresenceMessage.prototype.fail_on_any_message = function() {
 };
 
 PresenceMessage.prototype.for_client = function(client) {
-  if(client.configuration) {
+  if (client.configuration) {
     this.client = {
       userId: client.configuration('userId'),
       userType:  client.configuration('userType'),
@@ -161,12 +161,12 @@ PresenceMessage.prototype.assert_onlines_received = function() {
 
     for(i = 0; i < this.notifications.length; i++) {
       var value = this.notifications[i].value;
-      if(typeof value[uid] !== undefined && value[uid] === type) {
+      if (typeof value[uid] !== undefined && value[uid] === type) {
         assert.equal(online_idx, -1);
         online_idx = i;
         this.for_client(client).assert_online(this.notifications[i]);
       }
-      if(value.userId == uid && value.clientId == cid) {
+      if (value.userId == uid && value.clientId == cid) {
         assert.equal(client_online_idx, -1);
         client_online_idx = i;
         this.for_client(client).assert_client_online(this.notifications[i]);
@@ -184,7 +184,7 @@ PresenceMessage.prototype.for_online_clients = function() {
   var self = this;
   clients.forEach(function(client) {
     var clientHash = client;
-    if(client.configuration) {
+    if (client.configuration) {
       clientHash = {
         clientId: client.currentClientId(),
         userId: client.configuration('userId'),
@@ -239,7 +239,7 @@ PresenceMessage.prototype.assert_get_v2_response = function(message) {
   clients = this.online_clients || [];
   clients.forEach(function(client) {
     var userHash;
-    if(value[client.userId]) {
+    if (value[client.userId]) {
       userHash = value[client.userId];
     } else {
       value[client.userId] = userHash = { clients: {} };
@@ -465,10 +465,10 @@ StreamMessage.prototype.assert_get_response = function(response, list, idstart) 
 
 StreamMessage.prototype.assert_sync_error_notification = function(notification, state) {
   var error = { type: 'sync-error', from: state.from, size: state.size };
-  if(state.start >= 0) {
+  if (state.start >= 0) {
     error.start = state.start;
   }
-  if(state.end >= 0) {
+  if (state.end >= 0) {
     error.end = state.end;
   }
 
@@ -481,10 +481,10 @@ StreamMessage.prototype.assert_sync_error_notification = function(notification, 
 
 StreamMessage.prototype.assert_sync_error_get_response = function(response, state) {
   var error = { type: 'sync-error', from: state.from, size: state.size };
-  if(state.start >= 0) {
+  if (state.start >= 0) {
     error.start = state.start;
   }
-  if(state.end >= 0) {
+  if (state.end >= 0) {
     error.end = state.end;
   }
 

--- a/tests/lib/formatter.js
+++ b/tests/lib/formatter.js
@@ -4,7 +4,7 @@ var formatter = new Minilog.Transform();
 formatter.nameLength = 22;
 formatter.write = function(name, level, args) {
   var i;
-  if(this.nameLength < name.length) {
+  if (this.nameLength < name.length) {
     this.nameLength = name.length;
   }
   for(i = name.length; i < this.nameLength; i++) {
@@ -12,9 +12,9 @@ formatter.write = function(name, level, args) {
   }
   var result = [].concat(args);
   for(i = 0; i < result.length; i++) {
-    if(result[i] && typeof result[i] == 'object') {
+    if (result[i] && typeof result[i] == 'object') {
       // Buffers in Node.js look bad when stringified
-      if(result[i].constructor && result[i].constructor.isBuffer) {
+      if (result[i].constructor && result[i].constructor.isBuffer) {
         result[i] = result[i].toString();
       } else {
         try {

--- a/tests/lib/formatter.js
+++ b/tests/lib/formatter.js
@@ -20,8 +20,8 @@ formatter.write = function(name, level, args) {
         try {
           result[i] = JSON.stringify(result[i]);
         } catch(stringifyError) {
-          // happens when an object has a circular structure
-          // do not throw an error, when printing, the toString() method of the object will be used
+          // Happens when an object has a circular structure
+          // Do not throw an error, when printing, the toString() method of the object will be used
         }
       }
     } else {

--- a/tests/lib/radar.js
+++ b/tests/lib/radar.js
@@ -13,7 +13,7 @@ var http = require('http'),
 
 if(process.env.verbose) {
   var minilogPipe = Minilog;
-  // configure log output
+  // Configure log output
   if(process.env.radar_log) {
     minilogPipe = minilogPipe.pipe(Minilog.suggest.deny(/.*/, process.env.radar_log));
   }
@@ -119,8 +119,8 @@ Service.stop = function(arg, callback){
         logger.info('connections left', http_server._connections);
         var val = http_server.close();
         serverTimeout = setTimeout(function() {
-          //failsafe, because server.close does not always
-          //throw the close event within time.
+          // Failsafe, because server.close does not always
+          // throw the close event within time.
           if(serverStarted) {
             serverStarted = false;
             logger.info("Calling callback, timeout");

--- a/tests/lib/radar.js
+++ b/tests/lib/radar.js
@@ -11,10 +11,10 @@ var http = require('http'),
     formatter = require('./formatter.js'),
     radar, http_server, serverStarted = false;
 
-if(process.env.verbose) {
+if (process.env.verbose) {
   var minilogPipe = Minilog;
   // Configure log output
-  if(process.env.radar_log) {
+  if (process.env.radar_log) {
     minilogPipe = minilogPipe.pipe(Minilog.suggest.deny(/.*/, process.env.radar_log));
   }
   minilogPipe.pipe(formatter)
@@ -100,7 +100,7 @@ Service.stop = function(arg, callback){
   logger.info("stop");
   http_server.on('close', function() {
     logger.info("http_server closed");
-    if(serverStarted) {
+    if (serverStarted) {
       clearTimeout(serverTimeout);
       logger.info("Calling callback, close event");
       serverStarted = false;
@@ -110,7 +110,7 @@ Service.stop = function(arg, callback){
   Persistence.delWildCard('*', function() {
     radar.terminate(function() {
       logger.info("radar terminated");
-      if(!serverStarted) {
+      if (!serverStarted) {
         logger.info("http_server terminated");
         callback();
       }
@@ -121,7 +121,7 @@ Service.stop = function(arg, callback){
         serverTimeout = setTimeout(function() {
           // Failsafe, because server.close does not always
           // throw the close event within time.
-          if(serverStarted) {
+          if (serverStarted) {
             serverStarted = false;
             logger.info("Calling callback, timeout");
             callback();
@@ -143,7 +143,7 @@ process.on('message', function(message) {
     }));
   };
 
-  if(Service[command.action]) {
+  if (Service[command.action]) {
     Service[command.action](command.arg, complete);
   } else {
     complete('NotFound');

--- a/tests/message_list.unit.test.js
+++ b/tests/message_list.unit.test.js
@@ -95,7 +95,7 @@ describe('For a message list', function() {
 
       message_list.sync({
         send: function(msg) {
-          // check message
+          // Check message
           assert.equal('sync', msg.op);
           assert.equal('aab', msg.to);
           assert.deepEqual([1, 2], msg.value);

--- a/tests/message_list.unit.test.js
+++ b/tests/message_list.unit.test.js
@@ -127,7 +127,7 @@ describe('For a message list', function() {
   describe('unsubscribing', function() {
     it('renews expiry for maxPersistence', function(done) {
       var message_list = new MessageList('aab', Radar, { policy : { cache : true, maxPersistence : 24 * 60 * 60 } });
-      message_list.parent = { destroy: function() {} };
+      message_list.parent = { destroyResource: function() {} };
       FakePersistence.expire = function(name, expiry) {
         assert.equal(expiry, 24 * 60 * 60);
         setTimeout(done,1);

--- a/tests/presence.remote.test.js
+++ b/tests/presence.remote.test.js
@@ -33,15 +33,15 @@ exports['given a presence monitor'] = {
     presence.manager.once('user_online', function(userId, userType) {
       assert.equal(123, userId);
       assert.equal(0, userType);
-      // we assume that messages always arrive in separate ticks
+      // We assume that messages always arrive in separate ticks
       process.nextTick(function() {
         presence.manager.once('user_offline', function(userId, userType) {
           assert.equal(123, userId);
           assert.equal(0, userType);
           done();
         });
-        // remote and local messages are treated differently
-        // namely, remote messages about local clients cannot trigger the fast path
+        // Remote and local messages are treated differently
+        // Namely, remote messages about local clients cannot trigger the fast path
         presence.redisIn({ online: false, userId: 123, clientId: 'aab', userType: 0, sentry: Presence.sentry.name});
       });
     });
@@ -51,7 +51,7 @@ exports['given a presence monitor'] = {
   'messages from Redis are not broadcast, only changes in status are': function() {
     var presence = this.presence;
     var updates = [];
-    // replace function
+    // Replace function
     presence.manager.on('user_online', function(userId, userType) {
       updates.push([true, userId, userType]);
     });
@@ -69,7 +69,7 @@ exports['given a presence monitor'] = {
     assert.equal(1, updates.length);
     assert.deepEqual([true, 123, 2], updates[0]);
 
-    // receiving the same info twice should have no effect
+    // Receiving the same info twice should have no effect
     this.presence.redisIn({
       userId: 123,
       userType: 2,
@@ -79,7 +79,7 @@ exports['given a presence monitor'] = {
     });
     assert.equal(1, updates.length);
 
-    // if we receive a online message for a different client, send it
+    // If we receive a online message for a different client, send it
     this.presence.redisIn({
       userId: 345,
       userType: 0,
@@ -91,7 +91,7 @@ exports['given a presence monitor'] = {
     assert.equal(2, updates.length);
     assert.deepEqual([true, 345, 0], updates[1]);
 
-    // do not send notifications for users that were never online
+    // Do not send notifications for users that were never online
     this.presence.redisIn({
       userId: 456,
       userType: 2,
@@ -101,7 +101,7 @@ exports['given a presence monitor'] = {
     });
     assert.equal(2, updates.length);
 
-    // do send changes to user that were online
+    // Do send changes to user that were online
     this.presence.redisIn({
       userId: 123,
       userType: 2,
@@ -165,7 +165,7 @@ exports['given a presence monitor'] = {
   },
 
   'full reads exclude users that were set to online with an invalid sentry': function(done) {
-    // this may happen if the server gets terminated, so the key is never deleted properly...
+    // This may happen if the server gets terminated, so the key is never deleted properly...
     Persistence.readHashAll = function(scope, callback) {
       callback({
         123: { online: true, userId: 123, userType: 0, clientId: 'aab', sentry: 'unknown'},
@@ -180,7 +180,7 @@ exports['given a presence monitor'] = {
 
   'full reads cause change events based on what was previously known': function(done) {
     var presence = this.presence;
-    // make 123 online
+    // Make 123 online
     presence.redisIn({ online: true, userId: 123, userType: 0, clientId: 'aab', sentry: Presence.sentry.name });
 
     Persistence.readHashAll = function(scope, callback) {
@@ -210,7 +210,7 @@ exports['given a presence monitor'] = {
 
     Persistence.readHashAll = function(scope, callback) {
       callback({
-        // so, one clientId disconnected and another connected - at the same timestamp: user should be considered to be online
+        // So, one clientId disconnected and another connected - at the same timestamp: user should be considered to be online
         '200.aaz': { online: true, userId: 200, userType: 2, clientId: 'aaz', sentry: Presence.sentry.name },
         '200.sss': { online: false, userId: 200, userType: 2, clientId: 'sss', sentry: Presence.sentry.name },
         '200.1a': { online: false, userId: 200, userType: 2, clientId: '1a', sentry: Presence.sentry.name },

--- a/tests/presence.remote.test.js
+++ b/tests/presence.remote.test.js
@@ -5,7 +5,6 @@ var assert = require('assert'),
 
 var Server = {
   broadcast: function() { },
-  destroy: function() {},
   server: {
     clients: { }
   }

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -102,7 +102,7 @@ describe('given a presence resource',function() {
     });
 
     it('setting twice does not cause duplicate notifications', function() {
-      // see also: presence_monitor.test.js / test with the same name
+      // See also: presence_monitor.test.js / test with the same name
       var calls = 0;
       Persistence.publish = function(scope, m) {
         var online = m.online,
@@ -117,7 +117,9 @@ describe('given a presence resource',function() {
       };
       presence.set(client, { key: 1, type: 2, value: 'online' });
       presence.set(client, { key: 1, type: 2, value: 'online' });
-      assert.equal(2, calls); //persist twice, but only update once
+
+      // Persist twice, but only update once
+      assert.equal(2, calls);
       assert.ok(presence.manager.hasUser(1));
     });
   });
@@ -130,7 +132,7 @@ describe('given a presence resource',function() {
         var client_online_called = false;
 
         Persistence.publish = function(scope, m) {
-          //10ms delay
+          // 10ms delay
           setTimeout(function() {
             presence.redisIn(m);
           }, 10);
@@ -160,14 +162,18 @@ describe('given a presence resource',function() {
         presence.unsubscribe(client);
         // userExpiry timer is added
         assert.ok(presence.manager.expiryTimers[1]);
-        assert.ok(presence.manager.expiryTimers[1]._idleTimeout > 0); //active
+
+        // Active
+        assert.ok(presence.manager.expiryTimers[1]._idleTimeout > 0);
         assert.equal(Object.keys(presence.manager.expiryTimers).length, 1);
 
         presence.set(client2, { key: 1, type: 2, value: 'online' } );
         presence.unsubscribe(client2);
-        // no duplicates
+        // No duplicates
         assert.ok(presence.manager.expiryTimers[1]);
-        assert.ok(presence.manager.expiryTimers[1]._idleTimeout > 0); //active
+
+        // Active
+        assert.ok(presence.manager.expiryTimers[1]._idleTimeout > 0);
         assert.equal(Object.keys(presence.manager.expiryTimers).length, 1);
 
         done();
@@ -182,17 +188,21 @@ describe('given a presence resource',function() {
         assert.ok(!presence.manager.expiryTimers[1]);
         assert.equal(Object.keys(presence.manager.expiryTimers).length, 0);
         presence.unsubscribe(client);
-        // disconnect is queued
-        // userExpiry timer is added
+
+        // Disconnect is queued; userExpiry timer is added
         assert.ok(presence.manager.expiryTimers[1]);
-        assert.ok(presence.manager.expiryTimers[1]._idleTimeout > 0); //active
+
+        // Active
+        assert.ok(presence.manager.expiryTimers[1]._idleTimeout > 0);
         assert.equal(Object.keys(presence.manager.expiryTimers).length, 1);
 
         presence.set(client2, { key: 123, type: 0, value: 'online' } );
         presence.unsubscribe(client2);
         // userExpiry timer is added
         assert.ok(presence.manager.expiryTimers[123]);
-        assert.ok(presence.manager.expiryTimers[123]._idleTimeout > 0); //active
+
+        // Active
+        assert.ok(presence.manager.expiryTimers[123]._idleTimeout > 0);
         assert.equal(Object.keys(presence.manager.expiryTimers).length, 2);
 
 
@@ -206,20 +216,20 @@ describe('given a presence resource',function() {
         presence.broadcast = function(data) {
           local.push(data);
         };
-        // now client 1 reconnects
+        // Now client 1 reconnects
         presence.set(client, { key: 1, type: 2, value: 'online' } );
         // client 1 should emit periodic online and 123 should have emitted offline
         // one autopublish message
         assert.ok(remote.some(function(msg) { return msg.userId == 1 && msg.userType == 2 && msg.online; } ));
-        //timer is cleared
+        // Timer is cleared
         assert.ok(!presence.manager.expiryTimers[1]);
 
-        //invoke the timer fn manually:
+        // Invoke the timer fn manually:
         presence.manager.expiryTimers[123]._onTimeout();
         clearTimeout(presence.manager.expiryTimers[123]);
 
-        // one broadcast of a user offline
-        // first message is client_online for user 1
+        // One broadcast of a user offline
+        // First message is client_online for user 1
         assert.deepEqual(local[1], { to: 'aaa', op: 'offline', value: { '123': 0 } });
 
         presence.broadcast = oldBroadcast;
@@ -267,7 +277,7 @@ describe('given a presence resource',function() {
         presence.set(client, { key: 1, type: 2, value: 'offline' } );
 
         assert.equal(remote.length, 1);
-        // a client_offline should be sent for CID 1
+        // A client_offline should be sent for CID 1
         assert.ok(remote[0].at > Date.now()+59*60000);
         delete remote[0].at;
         assert.deepEqual(remote[0], { userId: 1,
@@ -279,7 +289,7 @@ describe('given a presence resource',function() {
 
         presence.set(client2, { key: 1, type: 2, value: 'offline' } );
 
-        // there should be a client_offline notification for CID 2
+        // There should be a client_offline notification for CID 2
         assert.equal(remote.length, 2);
         assert.ok(remote[1].at > Date.now()+59*60000);
         delete remote[1].at;
@@ -290,25 +300,25 @@ describe('given a presence resource',function() {
           explicit: true
         });
 
-        // check local broadcast
+        // Check local broadcast
         assert.equal(local.length, 3);
-        // there should be a client_offline notification for CID 1
+        // There should be a client_offline notification for CID 1
         assert.deepEqual(local[0],{ to: 'aaa',
           op: 'client_offline',
           explicit: true,
           value: { userId: 1, clientId: client.id }
         });
-        // there should be a client_offline notification for CID 2
+        // There should be a client_offline notification for CID 2
         assert.deepEqual(local[1],{ to: 'aaa',
           op: 'client_offline',
           explicit: true,
           value: { userId: 1, clientId: client2.id }
         });
-        // there should be a broadcast for a offline notification for UID 1
+        // There should be a broadcast for a offline notification for UID 1
         assert.deepEqual(local[2],  { to: 'aaa', op: 'offline', value: { 1: 2 } });
         assert.deepEqual(local[2].value, { 1: 2 });
 
-        // no notifications sent to the client themselves.
+        // No notifications sent to the client themselves.
         assert.equal(typeof messages[client.id], 'undefined');
         assert.equal(typeof messages[client2.id], 'undefined');
       });
@@ -318,7 +328,7 @@ describe('given a presence resource',function() {
         presence.unsubscribe(client);
 
         assert.equal(remote.length, 1);
-        // a client_offline should be sent for CID 1
+        // A client_offline should be sent for CID 1
         assert.equal(remote[0].online, false);
         assert.equal(remote[0].userId, 1);
         assert.equal(remote[0].clientId, client.id);
@@ -327,33 +337,33 @@ describe('given a presence resource',function() {
         presence.unsubscribe(client2);
 
         assert.equal(remote.length, 2);
-        // there should be a client_offline notification for CID 2
+        // There should be a client_offline notification for CID 2
         assert.equal(remote[1].userId, 1);
         assert.equal(remote[1].clientId, client2.id);
         assert.equal(remote[1].online, false);
         assert.ok(remote[1].at > Date.now()+59*60000);
 
-        // check local broadcast
+        // Check local broadcast
         assert.equal(local.length, 2);
-        // there should be a client_offline notification for CID 1
+        // There should be a client_offline notification for CID 1
         assert.equal(local[0].op, 'client_offline');
         assert.equal(local[0].value.userId, 1);
         assert.equal(local[0].value.clientId, client.id);
-        // there should be a client_offline notification for CID 2
+        // There should be a client_offline notification for CID 2
         assert.equal(local[1].op, 'client_offline');
         assert.equal(local[1].value.userId, 1);
         assert.equal(local[1].value.clientId, client2.id);
 
-        //Manually expire the timer
+        // Manually expire the timer
         presence.manager.expiryTimers[1]._onTimeout();
         clearTimeout(presence.manager.expiryTimers[1]);
 
-        // there should be a broadcast for a offline notification for UID 1
+        // There should be a broadcast for a offline notification for UID 1
         assert.equal(local.length, 3);
         assert.equal(local[2].op, 'offline');
         assert.deepEqual(local[2].value, { 1: 2 });
 
-        // no notifications sent to the client themselves.
+        // No notifications sent to the client themselves.
         assert.equal(typeof messages[client.id], 'undefined');
         assert.equal(typeof messages[client2.id], 'undefined');
       });
@@ -363,7 +373,7 @@ describe('given a presence resource',function() {
         presence.unsubscribe(client);
 
         assert.equal(remote.length, 1);
-        // a client_offline should be sent for CID 1
+        // A client_offline should be sent for CID 1
         assert.equal(remote[0].online, false);
         assert.equal(remote[0].userId, 1);
         assert.equal(remote[0].clientId, client.id);
@@ -371,27 +381,27 @@ describe('given a presence resource',function() {
 
         presence.set(client2, { key: 1, type: 2, value: 'offline' } );
 
-        // check local broadcast
+        // Check local broadcast
         assert.equal(local.length, 2);
-        // there should be a client_offline notification for CID 1
+        // There should be a client_offline notification for CID 1
         assert.equal(local[0].op, 'client_offline');
         assert.equal(local[0].value.userId, 1);
         assert.equal(local[0].value.clientId, client.id);
-        // there should be a client_offline notification for CID 2
+        // There should be a client_offline notification for CID 2
         assert.equal(local[1].op, 'client_offline');
         assert.equal(local[1].value.userId, 1);
         assert.equal(local[1].value.clientId, client2.id);
 
-        //Manually expire the timer
+        // Manually expire the timer
         presence.manager.expiryTimers[1]._onTimeout();
         clearTimeout(presence.manager.expiryTimers[1]);
 
-        // there should be a broadcast for a offline notification for UID 1
+        // There should be a broadcast for a offline notification for UID 1
         assert.equal(local.length, 3);
         assert.equal(local[2].op, 'offline');
         assert.deepEqual(local[2].value, { 1: 2 });
 
-        // no notifications sent to the client themselves.
+        // No notifications sent to the client themselves.
         assert.equal(typeof messages[client.id], 'undefined');
         assert.equal(typeof messages[client2.id], 'undefined');
       });

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -13,7 +13,7 @@ describe('given a presence resource',function() {
   var Server = {
     broadcast: function() { },
     terminate: function() { },
-    destroy: function() {},
+    destroyResource: function() {},
     server: {
       clients: { }
     }


### PR DESCRIPTION
This is a simple cleanup of radar code so that variables, properties, and functions are named more carefully to make the code more accurately reflect the underlying design, and to make the code more easily understandable by those unfamiliar with radar.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: 

### Risks
 - Low: There is the possibility of creating more confusion by the cleanup, but a code review will greatly reduce the risk of this.