### PR TITLE
Code refactoring in preparation for moving client state to radar server.

### DIFF
--- a/sample/views.js
+++ b/sample/views.js
@@ -33,7 +33,7 @@ function OnlineToggle(elId) {
 
 OnlineToggle.prototype.render = function() {
   this.el || (this.el = document.getElementById(this.elId));
-  var status = (model.online[RadarClient._me.userId] ? 'offline' : 'online');
+  var status = (model.online[RadarClient.configuration('userId')] ? 'offline' : 'online');
   this.el.innerHTML = '<a onclick="RadarClient.presence(\'foo\').set(\''+status+'\');" href="javascript:;">Go '+status+'</a>';
 
 };

--- a/server/server.js
+++ b/server/server.js
@@ -5,23 +5,14 @@ var MiniEventEmitter = require('miniee'),
     hostname = require('os').hostname(),
     DefaultEngineIO = require('engine.io');
 
-// Parse JSON
-function parseJSON(data) {
-  try {
-    var message = JSON.parse(data);
-    return message;
-  } catch(e) { }
-  return false;
-}
-
-MiniEventEmitter.mixin(Server);
-
 function Server() {
   this.server = null;
   this.resources = {};
   this.subscriber = null;
   this.subs = {};
 }
+
+MiniEventEmitter.mixin(Server);
 
 // Public API
 
@@ -139,7 +130,7 @@ Server.prototype._handlePubSubMessage = function(name, data) {
 
 // Process a client message
 Server.prototype._handleClientMessage = function(client, data) {
-  var message = parseJSON(data);
+  var message = _parseJSON(data);
 
   // Format check
   if (!message || !message.op || !message.to) {
@@ -193,5 +184,13 @@ Server.prototype._resourceGet = function(name) {
   }
   return this.resources[name];
 };
+
+function _parseJSON(data) {
+  try {
+    var message = JSON.parse(data);
+    return message;
+  } catch(e) { }
+  return false;
+}
 
 module.exports = Server;


### PR DESCRIPTION
  - don't use the naked _me reference
  - Identify APIs as public/private by
    - prefixing with _ (e.g. _handleClientMessage) where appropriate
    - regrouping of APIs in source files into public/private groups
  - rename APIs where needed (all private APIs)
  - expand comments minimally to clarify purpose of APIs

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-461

### Risks
 - Low: Minor refactoring, and very little new code in this step.