### PR TITLE
Change Auth to act on messages rather than on resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ notifications:
   flowdock:
     secure: eqo+1HteeVzHGckSQhvSG18sD7Eq/DdFSouaW3Mj7owW8gH83/utYgCU2DOiSn404wOqIv2MgI+CYzgoFQCoYaR98BgxYS2iike1GWkn+s53VFSS9WNkjWW/4W7Fm+g4fWEDnN00U4mIJK3G/9l+C2zDiSaRwuD+9K61o3QCWaM=
 branches:
-  only: [master, staging, production]
+  only: [master, staging, production, server_side_client_state]

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ notifications:
   flowdock:
     secure: eqo+1HteeVzHGckSQhvSG18sD7Eq/DdFSouaW3Mj7owW8gH83/utYgCU2DOiSn404wOqIv2MgI+CYzgoFQCoYaR98BgxYS2iike1GWkn+s53VFSS9WNkjWW/4W7Fm+g4fWEDnN00U4mIJK3G/9l+C2zDiSaRwuD+9K61o3QCWaM=
 branches:
-  only: [master, staging, production, server_side_client_state]
+  only: [master, staging, production, pobrien/server_side_client_state]

--- a/core/index.js
+++ b/core/index.js
@@ -8,6 +8,7 @@ module.exports = {
   Persistence: require('persistence'),
   Type: require('./lib/type.js'),
   PresenceManager: require('./lib/resources/presence/presence_manager.js'),
+  Auth: require('./lib/auth.js'),
 
   Resource: Resource,
   MessageList: MessageList,

--- a/core/lib/auth.js
+++ b/core/lib/auth.js
@@ -1,0 +1,23 @@
+var log = require('minilog')('radar:auth'),
+    Type = require('./type.js');
+
+function Auth () { };
+
+Auth.authorize = function (message, client, Core) {
+  var rtn = true;
+
+  var options = Type.getByExpression(message.to);
+  if (options) {
+    var provider = options && options.authProvider;
+    if (provider && provider.authorize) {
+      rtn = provider.authorize(options, message, client);
+    }
+  }
+  else {
+    log.info('#authorize: type not defined for name:', message.to);
+  }
+
+  return rtn;
+}
+
+module.exports = Auth;

--- a/core/lib/resource.js
+++ b/core/lib/resource.js
@@ -101,14 +101,6 @@ Resource.prototype.ack = function(client, sendAck) {
   }
 };
 
-Resource.prototype.authorize = function(message, client) {
-  var authProvider = this.options.authProvider;
-  if (authProvider && authProvider.authorize) {
-    return authProvider.authorize(this.options, message, client);
-  }
-  return true;
-};
-
 Resource.prototype.handleMessage = function(client, message) {
   switch(message.op) {
     case 'subscribe':

--- a/server/server.js
+++ b/server/server.js
@@ -134,41 +134,39 @@ Server.prototype._handleClientMessage = function(client, data) {
 
   // Format check
   if (!message || !message.op || !message.to) {
-    logging.warn('#client.message - rejected', (client && client.id), data);
+    logging.warn('#client.message - rejected', client.id, data);
     return;
   }
 
-  logging.info('#client.message - received', (client && client.id), message,
+  if (!this._messageAuthorize(message, client)) {
+    return;
+  }
+
+  logging.info('#client.message - received', client.id, message,
      (this.resources[message.to] ? 'exists' : 'not instantiated'),
      (this.subs[message.to] ? 'is subscribed' : 'not subscribed')
     );
 
   var resource = this._resourceGet(message.to);
-
-  if (resource && resource.authorize(message, client, data)) {
-    if (!this.subs[resource.name]) {
-      logging.info('#redis - subscribe', resource.name, (client && client.id));
-      this.subscriber.subscribe(resource.name, function(err) {
-        if (err) {
-          logging.error('#redis - subscribe failed', resource.name,
-                                          (client && client.id), err);
-        } else {
-          logging.info('#redis - subscribe successful', resource.name,
-                                          (client && client.id));
-        }
-      });
-      this.subs[resource.name] = true;
-    }
+  if (resource) {
+    this._persistenceSubscribe(resource.name, client.id)
     resource.handleMessage(client, message);
     this.emit(message.op, client, message);
-  } else {
-    logging.warn('#client.message - auth_invalid', data, (client && client.id));
+  }
+};
+
+// Authorize client message
+Server.prototype._messageAuthorize =  function (message, client, data) {
+  var rtn = Core.Auth.authorize(message, client);
+  if (!rtn) {
+    logging.warn('#client.message - auth_invalid', data, client.id);
     client.send({
       op: 'err',
       value: 'auth',
       origin: message
     });
   }
+  return rtn; 
 };
 
 // Get or create resource by name
@@ -184,6 +182,21 @@ Server.prototype._resourceGet = function(name) {
   }
   return this.resources[name];
 };
+
+// Subscribe to the persistence pubsub channel for a single resource
+Server.prototype._persistenceSubscribe = function (name, id) {
+  if (!this.subs[name]) {
+    logging.info('#redis - subscribe', name, id);
+    this.subscriber.subscribe(name, function(err) {
+      if (err) {
+        logging.error('#redis - subscribe failed', name, id, err);
+      } else {
+        logging.info('#redis - subscribe successful', name, id);
+      }
+    });
+    this.subs[name] = true;
+  }
+}
 
 function _parseJSON(data) {
   try {

--- a/server/server.js
+++ b/server/server.js
@@ -186,12 +186,12 @@ Server.prototype._resourceGet = function(name) {
 // Subscribe to the persistence pubsub channel for a single resource
 Server.prototype._persistenceSubscribe = function (name, id) {
   if (!this.subs[name]) {
-    logging.info('#redis - subscribe', name, id);
+    logging.debug('#redis - subscribe', name, id);
     this.subscriber.subscribe(name, function(err) {
       if (err) {
         logging.error('#redis - subscribe failed', name, id, err);
       } else {
-        logging.info('#redis - subscribe successful', name, id);
+        logging.debug('#redis - subscribe successful', name, id);
       }
     });
     this.subs[name] = true;


### PR DESCRIPTION
In preparation for needing auth for messages *other* than resources, refactor auth a little so that it acts on messages; remove *authorize()* from resource

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-470

### Risks
 - Low: code review should ensure resources are being authorized correctly