### PR TITLE
Persist client state for subscriptions/presences on server

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -10,14 +10,14 @@ function Client (name, id, accountName, version) {
   this.presences = {};
   this.key = this._keyGet(accountName);
   this.version = version;
-};
+}
 
 // 86400:  number of seconds in 1 day
 var DEFAULT_DATA_TTL = 86400;
 
 // Class properties
 Client.clients = {};                  // keyed by name
-Client.names = {}                     // keyed by id
+Client.names = {};                    // keyed by id
 Client.dataTTL = DEFAULT_DATA_TTL;
 
 require('util').inherits(Client, require('events').EventEmitter);
@@ -53,7 +53,7 @@ Client.create = function (message) {
   Client.clients[association.name] = client;
 
   return client;
-}
+};
 
 // Persist subscriptions and presences
 Client.prototype.dataStore = function (message) {

--- a/client/client.js
+++ b/client/client.js
@@ -57,8 +57,8 @@ Client.create = function (message) {
 
 // Persist subscriptions and presences
 Client.prototype.dataStore = function (message) {
-  subscriptions = this.subscriptions;
-  presences = this.presences;
+  var subscriptions = this.subscriptions;
+  var presences = this.presences;
 
   // Persist the message data, according to type
   var changed = true;

--- a/client/client.js
+++ b/client/client.js
@@ -1,21 +1,24 @@
 var log = require('minilog')('radar:client'),
     Core = require('../core');
 
-function Client (name, id) {
+function Client (name, id, accountName, version) {
   this.createdAt = Date.now();
   this.lastModified = Date.now();
   this.name = name;
   this.id = id;
   this.subscriptions = {};
   this.presences = {};
+  this.key = this._keyGet(accountName);
+  this.version = version;
 };
 
 // 86400:  number of seconds in 1 day
 var DEFAULT_DATA_TTL = 86400;
 
 // Class properties
-Client.clients = {};            // keyed by name
-Client.names = {}               // keyed by id
+Client.clients = {};                  // keyed by name
+Client.names = {}                     // keyed by id
+Client.dataTTL = DEFAULT_DATA_TTL;
 
 require('util').inherits(Client, require('events').EventEmitter);
 
@@ -23,14 +26,34 @@ require('util').inherits(Client, require('events').EventEmitter);
 
 // Class methods
 
-// Set up client name/id association, client key, and return client
-Client.get = function(id, name, accountName) {
-  Client.names[id] = name;
-  var client = Client._get(id, name);
-  client.key = Client._keyGet(name, accountName);
+// Set/Get the global client TTL
+Client.dataTTLSet = function (dataTTL) {
+  Client.dataTTL = dataTTL;
+};
+
+Client.dataTTLGet = function () {
+  return Client.dataTTL;
+};
+
+// Get current client associated with a given socket id
+Client.clientGet = function (id) {
+  var name = Client.names[id];
+  if (name) {
+    return Client.clients[name];
+  }
+};
+
+// Set up client name/id association, and return new client instance
+Client.create = function (message) {
+  var association = message.options.association;
+  Client.names[association.id] = association.name;
+  var client = Client._create(association.name, association.id,
+                              message.accountName, message.options.clientVersion);
+
+  Client.clients[association.name] = client;
 
   return client;
-};
+}
 
 // For a given client id/name pair, store the associated message
 Client.dataStore = function (id, message) {
@@ -44,8 +67,8 @@ Client.dataStore = function (id, message) {
     return false;
   }
 
-  // Fetch the current instance, or create a new one
-  var client = Client._get(id, name);
+  // Fetch the instance associated with the current name
+  var client = Client.clients[name];
 
   subscriptions = client.subscriptions;
   presences = client.presences;
@@ -76,51 +99,26 @@ Client.dataStore = function (id, message) {
 
   if (changed) {
     client.lastModified = Date.now();
-    Core.Persistence.persistKey(client.key, client);
-    Core.Persistence.expire(client.key, DEFAULT_DATA_TTL);
+    Core.Persistence.persistKey(client.key, client, Client.dataTTL);
   }
 
   return true;
 };
 
-// Read client state from persistence, when it exists for a given key
-Client.dataFromPersistenceLoad = function (client) {
-  if (client.key) {
-    // When we touch the client, refresh the TTL
-    Core.Persistence.expire(client.key, DEFAULT_DATA_TTL);
-
-    // Update current client with persisted subscriptions/presences
-    Core.Persistence.readKey(client.key, function (clientOld) {
-      if (clientOld) {
-        Client.clients[client.name].subscriptions = clientOld.subscriptions;
-        Client.clients[client.name].presences = clientOld.presences;
-      }
-      Client.clients[client.name].state = STATE_LOAD_DONE;
-    });
-  }
-};
-
-
 // Private API
 
 // Return the key used to persist client data
-Client._keyGet = function (name, accountName) {
-  var key= 'radar_client:/';
+Client.prototype._keyGet = function (accountName) {
+  var key = 'radar_client:/';
   key += accountName ? accountName + '/' : '/';
-  key += name;
+  key += this.name;
 
   return key;
 };
 
-// Get existing client, or return new client
-Client._get = function(id, name) {
-  var client = Client.clients[name];
-  if (!client) {
-    client = new Client(name, id);
-    Client.clients[name] = client;
-  }
-
-  return client;
+// Create new Client instance
+Client._create = function (name, id, accountName, version) {
+  return new Client(name, id, accountName, version);
 };
 
 module.exports = Client;

--- a/client/client.js
+++ b/client/client.js
@@ -1,0 +1,126 @@
+var log = require('minilog')('radar:client'),
+    Core = require('../core');
+
+function Client (name, id) {
+  this.createdAt = Date.now();
+  this.lastModified = Date.now();
+  this.name = name;
+  this.id = id;
+  this.subscriptions = {};
+  this.presences = {};
+};
+
+// 86400:  number of seconds in 1 day
+var DEFAULT_DATA_TTL = 86400;
+
+// Class properties
+Client.clients = {};            // keyed by name
+Client.names = {}               // keyed by id
+
+require('util').inherits(Client, require('events').EventEmitter);
+
+// Public API
+
+// Class methods
+
+// Set up client name/id association, client key, and return client
+Client.get = function(id, name, accountName) {
+  Client.names[id] = name;
+  var client = Client._get(id, name);
+  client.key = Client._keyGet(name, accountName);
+
+  return client;
+};
+
+// For a given client id/name pair, store the associated message
+Client.dataStore = function (id, message) {
+  var name;
+
+  if (Client.names[id]) {
+    name = Client.names[id];
+  }
+  else {
+    log.error('client id:', id, 'does not have corresponding name');
+    return false;
+  }
+
+  // Fetch the current instance, or create a new one
+  var client = Client._get(id, name);
+
+  subscriptions = client.subscriptions;
+  presences = client.presences;
+
+  // Persist the message data, according to type
+  var changed = true;
+  switch(message.op) {
+    case 'unsubscribe':
+      if (subscriptions[message.to]) {
+        delete subscriptions[message.to];
+      }
+      break;
+
+    case 'sync':
+    case 'subscribe':
+      subscriptions[message.to] = message.op;
+      break;
+
+    case 'set':
+      if (message.to.substr(0, 'presence:/'.length) == 'presence:/') {
+        presences[message.to] = message.value;
+      }
+      break;
+
+    default:
+      changed = false;
+  }
+
+  if (changed) {
+    client.lastModified = Date.now();
+    Core.Persistence.persistKey(client.key, client);
+    Core.Persistence.expire(client.key, DEFAULT_DATA_TTL);
+  }
+
+  return true;
+};
+
+// Read client state from persistence, when it exists for a given key
+Client.dataFromPersistenceLoad = function (client) {
+  if (client.key) {
+    // When we touch the client, refresh the TTL
+    Core.Persistence.expire(client.key, DEFAULT_DATA_TTL);
+
+    // Update current client with persisted subscriptions/presences
+    Core.Persistence.readKey(client.key, function (clientOld) {
+      if (clientOld) {
+        Client.clients[client.name].subscriptions = clientOld.subscriptions;
+        Client.clients[client.name].presences = clientOld.presences;
+      }
+      Client.clients[client.name].state = STATE_LOAD_DONE;
+    });
+  }
+};
+
+
+// Private API
+
+// Return the key used to persist client data
+Client._keyGet = function (name, accountName) {
+  var key= 'radar_client:/';
+  key += accountName ? accountName + '/' : '/';
+  key += name;
+
+  return key;
+};
+
+// Get existing client, or return new client
+Client._get = function(id, name) {
+  var client = Client.clients[name];
+  if (!client) {
+    client = new Client(name, id);
+    Client.clients[name] = client;
+  }
+
+  return client;
+};
+
+module.exports = Client;

--- a/configuration.js
+++ b/configuration.js
@@ -47,5 +47,7 @@ module.exports = {
 
   // Radar config: (optional), not currently set, interval for datadog reporting
   healthReportInterval: 10000,
-};
 
+  // TTL for data stored on the server, in seconds (86400 = 1 day)
+  clientDataOnServerTTL: 86400
+};

--- a/configuration.js
+++ b/configuration.js
@@ -49,5 +49,5 @@ module.exports = {
   healthReportInterval: 10000,
 
   // TTL for data stored on the server, in seconds (86400 = 1 day)
-  clientDataOnServerTTL: 86400
+  clientDataTTL: 86400
 };

--- a/core/lib/auth.js
+++ b/core/lib/auth.js
@@ -1,7 +1,7 @@
 var log = require('minilog')('radar:auth'),
     Type = require('./type.js');
 
-function Auth () { };
+function Auth () { }
 
 Auth.authorize = function (message, client, Core) {
   var rtn = true;
@@ -18,6 +18,6 @@ Auth.authorize = function (message, client, Core) {
   }
 
   return rtn;
-}
+};
 
 module.exports = Auth;

--- a/core/lib/resource.js
+++ b/core/lib/resource.js
@@ -88,7 +88,7 @@ Resource.prototype.redisIn = function(data) {
 // Return a client reference
 Resource.prototype.clientGet = function (id) {
   return this.parent.server.clients[id];
-}
+};
 
 Resource.prototype.ack = function(client, sendAck) {
   if (client && client.send && sendAck) {

--- a/core/lib/resources/presence/index.js
+++ b/core/lib/resources/presence/index.js
@@ -127,7 +127,7 @@ Presence.prototype._set_online = function(client) {
     this.subscribe(client);
 
     // We are subscribed, but not listening
-    this.subscribers[client.id] = { listening: false }
+    this.subscribers[client.id] = { listening: false };
   }
 };
 

--- a/core/lib/type.js
+++ b/core/lib/type.js
@@ -21,6 +21,11 @@ var Types = [
     name: 'general stream',
     type: 'Stream',
     expression: /^stream:/
+  },
+  {
+    name: 'general control',
+    type: 'Control',
+    expression: /^control:/
   }
 ];
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "radar_client": "0.13.1",
+    "radar_client": "0.14.0",
     "simple_sentinel": "*"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "minilog": "*",
     "callback_tracker": "*",
     "underscore": "*",
-    "persistence": "*"
+    "persistence": "*",
+    "semver": "*"
   },
   "devDependencies": {
     "mocha": "*",
@@ -56,6 +57,7 @@
     "test-sentinel": "ls ./tests/*.test.js | xargs -n 1 -t -I {} sh -c 'TEST=\"{}\" radar_connection=cluster1 npm run test-one'",
     "posttest-sentinel": "./node_modules/.bin/simple_sentinel stop",
     "test-one": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --timeout 4000ms --bail \"$TEST\"",
+    "test-one-solo": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --timeout 4000ms --bail",
     "test-debug": "./node_modules/.bin/mocha debug --ui exports --reporter spec --slow 4000ms --bail \"$TEST\""
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -183,7 +183,7 @@ Server.prototype._resourceMessageHandle = function (client, message) {
       (this.subs[message.to] ? 'is subscribed' : 'not subscribed')
       );
 
-    this._persistenceSubscribe(resource.name, client.id)
+    this._persistenceSubscribe(resource.name, client.id);
     resource.handleMessage(client, message);
     this.emit(message.op, client, message);
   }
@@ -244,6 +244,6 @@ function _parseJSON(data) {
     return message;
   } catch(e) { }
   return false;
-};
+}
 
 module.exports = Server;

--- a/server/server.js
+++ b/server/server.js
@@ -21,6 +21,7 @@ MiniEventEmitter.mixin(Server);
 // Attach to a http server
 Server.prototype.attach = function(http_server, configuration) {
   this.configuration = configuration;
+  Client.dataTTLSet(this.configuration.clientDataTTL);
   Core.Persistence.setConfig(configuration);
   Core.Persistence.connect(this._setup.bind(this, http_server));
 };
@@ -165,9 +166,8 @@ Server.prototype._clientDataPersist = function (socket, message) {
   }
   else {
     var client = Client.clientGet(socket.id);
-    if (client && Semver.gte(client.version, VERSION_CLIENT_DATASTORE) &&
-        !Client.dataStore(socket.id, message)) {
-      return false;
+    if (client && Semver.gte(client.version, VERSION_CLIENT_DATASTORE)) {
+      client.dataStore(message);
     }
   }
 
@@ -235,7 +235,6 @@ Server.prototype._persistenceSubscribe = function (name, id) {
 
 // On name_id_sync, initialize the current client
 Server.prototype._clientInit = function (initMessage) {
-  Client.dataTTLSet(this.configuration.clientDataTTL);
   Client.create(initMessage);
 };
 

--- a/server/server.js
+++ b/server/server.js
@@ -161,6 +161,7 @@ Server.prototype._clientDataPersist = function (socket, message) {
     this._clientInit(message);
 
     socket.send({ op: 'ack', value: message && message.ack });
+    return false;
   }
   else {
     var client = Client.clientGet(socket.id);

--- a/tests/client.connect.test.js
+++ b/tests/client.connect.test.js
@@ -1,0 +1,35 @@
+var common = require('./common.js'),
+    assert = require('assert'),
+    Client = require('radar_client').constructor,
+    Tracker = require('callback_tracker'),
+    radar, client;
+
+describe('Once radar server is running', function() {
+  before(function(done) {
+    var track = Tracker.create('before', done);
+
+    radar = common.spawnRadar();
+    radar.sendCommand('start', common.configuration,  function() {
+      client = common.getClient('dev', 123, 0, {}, track('client 1 ready'));
+    });
+  });
+
+  afterEach(function() {
+    client.dealloc('test');
+  });
+
+  after(function(done) {
+    common.stopRadar(radar, done);
+  });
+
+  it('a client can nameSync successfully with ack', function(done) {
+    var association = { id: 1, name: 'test_name' };
+    var options = { association: association, clientVersion: '1.0.0' };
+
+    client.control('test').nameSync(options, function(msg) {
+      assert.equal('nameSync', msg.op);
+      assert.equal('control:/dev/test', msg.to);
+      done();
+    });
+  });
+});

--- a/tests/client.presence.test.js
+++ b/tests/client.presence.test.js
@@ -281,7 +281,7 @@ describe('given two clients and a presence resource', function() {
           ]);
 
           // Ensure time between implicit_offline and offline is within range
-          p.assert_delay_between_notifications_within_range(2, 3, 14500, 15500)
+          p.assert_delay_between_notifications_within_range(2, 3, 14500, 15500);
 
           done();
         });

--- a/tests/client.reconnect.test.js
+++ b/tests/client.reconnect.test.js
@@ -95,7 +95,7 @@ describe('When radar server restarts', function() {
   it('reestablishes presence', function(done) {
     this.timeout(4000);
     var verifySubscriptions = function() {
-      client2.presence('restore').get(function(message) {
+      client.presence('restore').get(function(message) {
         assert.equal('get', message.op);
         assert.equal('presence:/test/restore', message.to);
         assert.deepEqual({ 123 : 0 }, message.value);
@@ -104,7 +104,7 @@ describe('When radar server restarts', function() {
     };
 
     client.presence('restore').set('online', function() {
-      common.restartRadar(radar, common.configuration, [client, client2], verifySubscriptions);
+      common.restartRadar(radar, common.configuration, [client], verifySubscriptions);
     });
   });
   it('must not repeat synced chat (messagelist) messages, with two clients', function(done) {

--- a/tests/client.reconnect.test.js
+++ b/tests/client.reconnect.test.js
@@ -7,7 +7,6 @@ var common = require('./common.js'),
     Tracker = require('callback_tracker'),
     radar;
 
-
 describe('When radar server restarts', function() {
   var client, client2;
 
@@ -95,7 +94,7 @@ describe('When radar server restarts', function() {
   it('reestablishes presence', function(done) {
     this.timeout(4000);
     var verifySubscriptions = function() {
-      client.presence('restore').get(function(message) {
+      client2.presence('restore').get(function(message) {
         assert.equal('get', message.op);
         assert.equal('presence:/test/restore', message.to);
         assert.deepEqual({ 123 : 0 }, message.value);
@@ -104,7 +103,7 @@ describe('When radar server restarts', function() {
     };
 
     client.presence('restore').set('online', function() {
-      common.restartRadar(radar, common.configuration, [client], verifySubscriptions);
+      common.restartRadar(radar, common.configuration, [client, client2], verifySubscriptions);
     });
   });
   it('must not repeat synced chat (messagelist) messages, with two clients', function(done) {

--- a/tests/client.status.test.js
+++ b/tests/client.status.test.js
@@ -36,6 +36,7 @@ describe('When using status resources', function() {
     it('should subscribe successfully with ack', function(done) {
 
       client.status('test').subscribe(function(msg) {
+        console.log('msg:', msg);
         assert.equal('subscribe', msg.op);
         assert.equal('status:/dev/test', msg.to);
         done();

--- a/tests/client.status.test.js
+++ b/tests/client.status.test.js
@@ -36,7 +36,6 @@ describe('When using status resources', function() {
     it('should subscribe successfully with ack', function(done) {
 
       client.status('test').subscribe(function(msg) {
-        console.log('msg:', msg);
         assert.equal('subscribe', msg.op);
         assert.equal('status:/dev/test', msg.to);
         done();

--- a/tests/lib/radar.js
+++ b/tests/lib/radar.js
@@ -69,7 +69,12 @@ Type.add([
       expression: /^stream:\/dev\/uncached_stream\/(.+)/,
       type: 'Stream',
       policy: { maxLength: 0 }
-    }
+    },
+  {
+    name: 'general control',
+    type: 'Control',
+    expression: /^control:/
+  }
 ]);
 
 var Service = {};


### PR DESCRIPTION
Persist client state for subscriptions & presences on the server, by means of a new Client class.  Client data is stored in persistence, keyed by the UUID and accountName passed by the client to the server, via the name_id_sync message.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team
 - [ ] :+1: add more tests

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-472

### Risks
 - Low: current production client does not send name_id_sync message to server