### PR TITLE
In many places, replace *client* with *socket* for the sake of clarity

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -36,7 +36,7 @@ Client.dataTTLGet = function () {
 };
 
 // Get current client associated with a given socket id
-Client.clientGet = function (id) {
+Client.get = function (id) {
   var name = Client.names[id];
   if (name) {
     return Client.clients[name];

--- a/core/lib/auth.js
+++ b/core/lib/auth.js
@@ -3,14 +3,14 @@ var log = require('minilog')('radar:auth'),
 
 function Auth () { }
 
-Auth.authorize = function (message, client, Core) {
+Auth.authorize = function (message, socket) {
   var rtn = true;
 
   var options = Type.getByExpression(message.to);
   if (options) {
     var provider = options && options.authProvider;
     if (provider && provider.authorize) {
-      rtn = provider.authorize(options, message, client);
+      rtn = provider.authorize(options, message, socket);
     }
   }
   else {

--- a/core/lib/resources/presence/presence_store.js
+++ b/core/lib/resources/presence/presence_store.js
@@ -4,28 +4,28 @@ function PresenceStore(scope) {
   this.scope = scope;
   this.map = {};
   this.cache = {};
-  this.clientUserMap = {};
+  this.socketUserMap = {};
   this.userTypes = {};
 }
 
 require('util').inherits(PresenceStore, require('events').EventEmitter);
 
 // Cache the client data without adding
-PresenceStore.prototype.cacheAdd = function(clientId, data) {
-  this.cache[clientId] = data;
+PresenceStore.prototype.cacheAdd = function(socketId, data) {
+  this.cache[socketId] = data;
 };
 
-PresenceStore.prototype.cacheRemove = function(clientId) {
-  var val = this.cache[clientId];
-  delete this.cache[clientId];
+PresenceStore.prototype.cacheRemove = function(socketId) {
+  var val = this.cache[socketId];
+  delete this.cache[socketId];
   return val;
 };
 
-PresenceStore.prototype.add = function(clientId, userId, userType, data) {
+PresenceStore.prototype.add = function(socketId, userId, userType, data) {
   var store = this,
       events = [];
-  logging.debug('#presence - store.add', userId, clientId, data, this.scope);
-  this.cacheRemove(clientId);
+  logging.debug('#presence - store.add', userId, socketId, data, this.scope);
+  this.cacheRemove(socketId);
 
   if (!this.map[userId]) {
     events.push('user_added');
@@ -33,10 +33,10 @@ PresenceStore.prototype.add = function(clientId, userId, userType, data) {
     this.userTypes[userId] = userType;
   }
 
-  if (!this.map[userId][clientId]) {
+  if (!this.map[userId][socketId]) {
     events.push('client_added');
-    this.map[userId][clientId] = data;
-    this.clientUserMap[clientId] = userId;
+    this.map[userId][socketId] = data;
+    this.socketUserMap[socketId] = userId;
   }
 
   events.forEach(function(ev) {
@@ -45,20 +45,20 @@ PresenceStore.prototype.add = function(clientId, userId, userType, data) {
   });
 };
 
-PresenceStore.prototype.remove = function(clientId, userId, data) {
+PresenceStore.prototype.remove = function(socketId, userId, data) {
   var store = this,
       events = [];
-  logging.debug('#presence - store.remove', userId, clientId, data, this.scope);
-  this.cacheRemove(clientId);
+  logging.debug('#presence - store.remove', userId, socketId, data, this.scope);
+  this.cacheRemove(socketId);
 
   // When non-existent, return
-  if (!this.map[userId] || !this.map[userId][clientId]) {
+  if (!this.map[userId] || !this.map[userId][socketId]) {
     return;
   }
 
   events.push('client_removed');
-  delete this.map[userId][clientId];
-  delete this.clientUserMap[clientId];
+  delete this.map[userId][socketId];
+  delete this.socketUserMap[socketId];
 
   // Empty user
   if (Object.keys(this.map[userId]).length === 0) {
@@ -73,20 +73,20 @@ PresenceStore.prototype.remove = function(clientId, userId, data) {
   });
 };
 
-PresenceStore.prototype.removeClient = function(clientId, data) {
-  var userId = this.clientUserMap[clientId];
-  this.cacheRemove(clientId);
+PresenceStore.prototype.removeClient = function(socketId, data) {
+  var userId = this.socketUserMap[socketId];
+  this.cacheRemove(socketId);
 
   // When non-existent, return
   if (!userId) {
     logging.warn('#presence - store.removeClient: cannot find data for',
-                                                      clientId, this.scope);
+                                                      socketId, this.scope);
     return;
   }
 
-  logging.debug('#presence - store.removeClient', userId, clientId, data, this.scope);
-  delete this.map[userId][clientId];
-  delete this.clientUserMap[clientId];
+  logging.debug('#presence - store.removeClient', userId, socketId, data, this.scope);
+  delete this.map[userId][socketId];
+  delete this.socketUserMap[socketId];
 
   logging.debug('#presence - store.emit', 'client_removed', data, this.scope);
   this.emit('client_removed', data);
@@ -102,27 +102,27 @@ PresenceStore.prototype.removeUserIfEmpty = function(userId, data) {
   }
 };
 
-PresenceStore.prototype.userOf = function(clientId) {
-  return this.clientUserMap[clientId];
+PresenceStore.prototype.userOf = function(socketId) {
+  return this.socketUserMap[socketId];
 };
 
-PresenceStore.prototype.get = function(clientId, userId) {
-  return (this.map[userId] && this.map[userId][clientId]);
+PresenceStore.prototype.get = function(socketId, userId) {
+  return (this.map[userId] && this.map[userId][socketId]);
 };
 
 PresenceStore.prototype.users = function() {
   return Object.keys(this.map);
 };
 
-PresenceStore.prototype.clients = function(userId) {
+PresenceStore.prototype.sockets = function(userId) {
   return ((this.map[userId] && Object.keys(this.map[userId])) || []);
 };
 
 PresenceStore.prototype.forEachClient = function(callback) {
   var store = this;
   this.users().forEach(function(userId) {
-    store.clients(userId).forEach(function(clientId) {
-      if (callback) callback(userId, clientId, store.get(clientId, userId));
+    store.sockets(userId).forEach(function(socketId) {
+      if (callback) callback(userId, socketId, store.get(socketId, userId));
     });
   });
 };
@@ -140,21 +140,21 @@ PresenceStore.prototype.userExists = function(userId) {
 };
 
 
-// This returns a list of clientIds, which is not costly.  The code that calls
-// this code uses each clientId in a separate chained call, the sum of which is
+// This returns a list of socketIds, which is not costly.  The code that calls
+// this code uses each socketId in a separate chained call, the sum of which is
 // costly.
-PresenceStore.prototype.clientsForSentry = function(sentry) {
-  var map = this.map, clientIds = [];
+PresenceStore.prototype.socketsForSentry = function(sentry) {
+  var map = this.map, socketIds = [];
   Object.keys(map).forEach(function(userId) {
-    Object.keys(map[userId]).forEach(function(clientId) {
-      var data = map[userId][clientId];
+    Object.keys(map[userId]).forEach(function(socketId) {
+      var data = map[userId][socketId];
       if (data && data.sentry == sentry) {
-        clientIds.push(clientId);
+        socketIds.push(socketId);
       }
     });
   });
 
-  return clientIds;
+  return socketIds;
 };
 
 module.exports = PresenceStore;

--- a/core/lib/resources/status.js
+++ b/core/lib/resources/status.js
@@ -16,11 +16,11 @@ Status.prototype = new Resource();
 Status.prototype.type = 'status';
 
 // Get status
-Status.prototype.get = function(client) {
+Status.prototype.get = function(socket) {
   var name = this.name;
-  logger.debug('#status - get', this.name, (client && client.id));
+  logger.debug('#status - get', this.name, (socket && socket.id));
   this._get(name, function(replies) {
-    client.send({
+    socket.send({
       op: 'get',
       to: name,
       value: replies || {}
@@ -32,11 +32,11 @@ Status.prototype._get = function(name, callback) {
   Persistence.readHashAll(name, callback);
 };
 
-Status.prototype.set = function(client, message) {
+Status.prototype.set = function(socket, message) {
   var self = this;
-  logger.debug('#status - set', this.name, message, (client && client.id));
+  logger.debug('#status - set', this.name, message, (socket && socket.id));
   Status.prototype._set(this.name, message, this.options.policy, function() {
-    self.ack(client, message.ack);
+    self.ack(socket, message.ack);
   });
 };
 
@@ -51,10 +51,10 @@ Status.prototype._set = function(scope, message, policy, callback) {
   Persistence.publish(scope, message, callback);
 };
 
-Status.prototype.sync = function(client) {
-  logger.debug('#status - sync', this.name, (client && client.id));
-  this.subscribe(client, false);
-  this.get(client);
+Status.prototype.sync = function(socket) {
+  logger.debug('#status - sync', this.name, (socket && socket.id));
+  this.subscribe(socket, false);
+  this.get(socket);
 };
 
 Status.setBackend = function(backend) { Persistence = backend; };

--- a/core/lib/resources/stream/subscriber_state.js
+++ b/core/lib/resources/stream/subscriber_state.js
@@ -1,5 +1,5 @@
-function StreamSubscriber(clientId) {
-  this.id = clientId;
+function StreamSubscriber(socketId) {
+  this.id = socketId;
   this.sent = null;
   this.sendEnabled = true;
 }
@@ -21,15 +21,15 @@ function SubscriberState() {
   this.subscribers = {};
 }
 
-SubscriberState.prototype.get = function(clientId) {
-  if (!this.subscribers[clientId]) {
-    this.subscribers[clientId] = new StreamSubscriber(clientId);
+SubscriberState.prototype.get = function(socketId) {
+  if (!this.subscribers[socketId]) {
+    this.subscribers[socketId] = new StreamSubscriber(socketId);
   }
-  return this.subscribers[clientId];
+  return this.subscribers[socketId];
 };
 
-SubscriberState.prototype.remove = function(clientId) {
-  delete this.subscribers[clientId];
+SubscriberState.prototype.remove = function(socketId) {
+  delete this.subscribers[socketId];
 };
 
 module.exports = SubscriberState;


### PR DESCRIPTION
In many places, replace the identifier *client* with the identifier *socket*, to remove confusion because of the new server-side client class and objects.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-473

### Risks
 - Low: once a review of the 232 changes made verifies that no mistakes were made in renaming