### PR TITLE
Restore presences and subscription on receipt of nameSync message

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -115,12 +115,14 @@ Client.prototype.dataLoad = function (callback) {
       self.subscriptions = clientOld.subscriptions;
       self.presences = clientOld.presences;
 
+      // Remove obsolete presences
       Client._presencesDelete(self.presences, clientOld.id);
 
       if (callback) {
         callback();
-        self._persist();
       }
+
+      self._persist();
     }
 
     self.state = STATE_LOAD_DONE;

--- a/core/lib/auth.js
+++ b/core/lib/auth.js
@@ -4,20 +4,20 @@ var log = require('minilog')('radar:auth'),
 function Auth () { }
 
 Auth.authorize = function (message, socket) {
-  var rtn = true;
+  var isAuthorized = true;
 
   var options = Type.getByExpression(message.to);
   if (options) {
     var provider = options && options.authProvider;
     if (provider && provider.authorize) {
-      rtn = provider.authorize(options, message, socket);
+      isAuthorized = provider.authorize(options, message, socket);
     }
   }
   else {
     log.info('#authorize: type not defined for name:', message.to);
   }
 
-  return rtn;
+  return isAuthorized;
 };
 
 module.exports = Auth;

--- a/core/lib/resources/stream/index.js
+++ b/core/lib/resources/stream/index.js
@@ -113,7 +113,6 @@ Stream.prototype.push = function(socket, message) {
 
   this.list.push(m, function(error, stamped) {
     if (error) {
-      console.log(error);
       logging.error(error);
       return;
     }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "callback_tracker": "*",
     "underscore": "*",
     "persistence": "*",
-    "semver": "*"
+    "semver": "*",
+    "pauseable": "*"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
- load presences and subscriptions from Persistence, then restore
- pause inbound socket while applying restored messages (this buffers inbound events on the socket)
- resume inbound socket - this applies the buffered events

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-474

### Risks
 - Low: the current radar_client will not exercise this code, but the next version of radar_client will