### PR TITLE
Disambiguate server naming

### DIFF
--- a/core/lib/resource.js
+++ b/core/lib/resource.js
@@ -37,10 +37,10 @@ function recursiveMerge(target) {
   return target;
 }
 
-function Resource(name, parent, options, default_options) {
+function Resource(name, server, options, default_options) {
   this.name = name;
   this.subscribers = {};
-  this.parent = parent;
+  this.server = server; // RadarServer instance
   this.options = recursiveMerge({}, options || {}, default_options || {});
 }
 
@@ -65,7 +65,7 @@ Resource.prototype.unsubscribe = function(socket, message) {
   if (!Object.keys(this.subscribers).length) {
     logging.info('#'+this.type, '- destroying resource', this.name,
                                           this.subscribers, socket.id);
-    this.parent.destroyResource(this.name);
+    this.server.destroyResource(this.name);
   }
 
   this.ack(socket, message && message.ack);
@@ -87,7 +87,7 @@ Resource.prototype.redisIn = function(data) {
 
 // Return a socket reference; eio server hash is "clients", not "sockets"
 Resource.prototype.socketGet = function (id) {
-  return this.parent.server.clients[id];
+  return this.server.socketServer.clients[id];
 };
 
 Resource.prototype.ack = function(socket, sendAck) {

--- a/core/lib/resources/message_list.js
+++ b/core/lib/resources/message_list.js
@@ -12,8 +12,8 @@ var default_options = {
 // This includes even the final unsubscribe, in case a client decides to rejoin
 // after being the last user.
 
-function MessageList(name, parent, options) {
-  Resource.call(this, name, parent, options, default_options);
+function MessageList(name, server, options) {
+  Resource.call(this, name, server, options, default_options);
 }
 
 MessageList.prototype = new Resource();

--- a/core/lib/resources/presence/index.js
+++ b/core/lib/resources/presence/index.js
@@ -19,8 +19,8 @@ shasum.update(require('os').hostname() + ' ' + Math.random() + ' ' + Date.now())
 var sentryName = shasum.digest('hex').slice(0,15);
 Presence.sentry = new Sentry(sentryName);
 
-function Presence(name, parent, options) {
-  Resource.call(this, name, parent, options, default_options);
+function Presence(name, server, options) {
+  Resource.call(this, name, server, options, default_options);
   this.setup();
 }
 
@@ -140,7 +140,7 @@ Presence.prototype.unsubscribe = function(socket, message) {
   logging.info('#presence - implicit disconnect', socket.id, this.name);
   this.manager.disconnectClient(socket.id);
 
-  // Call parent
+  // Call server
   Resource.prototype.unsubscribe.call(this, socket, message);
 };
 

--- a/core/lib/resources/presence/index.js
+++ b/core/lib/resources/presence/index.js
@@ -140,7 +140,6 @@ Presence.prototype.unsubscribe = function(socket, message) {
   logging.info('#presence - implicit disconnect', socket.id, this.name);
   this.manager.disconnectClient(socket.id);
 
-  // Call server
   Resource.prototype.unsubscribe.call(this, socket, message);
 };
 

--- a/core/lib/resources/status.js
+++ b/core/lib/resources/status.js
@@ -8,8 +8,8 @@ var default_options = {
   }
 };
 
-function Status(name, parent, options) {
-  Resource.call(this, name, parent, options, default_options);
+function Status(name, server, options) {
+  Resource.call(this, name, server, options, default_options);
 }
 
 Status.prototype = new Resource();

--- a/core/lib/resources/stream/index.js
+++ b/core/lib/resources/stream/index.js
@@ -10,8 +10,8 @@ var default_options = {
   }
 };
 
-function Stream(name, parent, options) {
-  Resource.call(this, name, parent, options, default_options);
+function Stream(name, server, options) {
+  Resource.call(this, name, server, options, default_options);
   this.list = new Persistence.List(name, this.options.policy.maxPersistence, this.options.policy.maxLength);
   this.subscriberState = new SubscriberState();
 }

--- a/server.js
+++ b/server.js
@@ -15,13 +15,13 @@ function p404(req, res){
   res.end('404 Not Found');
 }
 
-var server = http.createServer(p404);
+var httpServer = http.createServer(p404);
 
 // Radar API
-Api.attach(server);
+Api.attach(httpServer);
 
 // Radar server
 var radar = new Radar();
-radar.attach(server, configuration);
+radar.attach(httpServer, configuration);
 
-server.listen(configuration.port);
+httpServer.listen(configuration.port);

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,7 @@ var MiniEventEmitter = require('miniee'),
     Client = require('../client/client.js');
 
 function Server() {
-  this.server = null;
+  this.socketServer = null;
   this.resources = {};
   this.subscriber = null;
   this.subs = {};
@@ -44,7 +44,7 @@ Server.prototype.terminate = function(done) {
   });
 
   Core.Resources.Presence.sentry.stop();
-  this.server.close();
+  this.socketServer.close();
   Core.Persistence.disconnect(done);
 };
 
@@ -73,8 +73,8 @@ Server.prototype._setup = function(httpServer) {
                 configuration.engineio.conf.path : 'default';
   }
 
-  this.server.on('connection', this._onSocketConnection.bind(this));
   this.socketServer = engine.attach(httpServer, engineConf);
+  this.socketServer.on('connection', this._onSocketConnection.bind(this));
 
   logging.debug('#server - start ' + new Date().toString());
   this.emit('ready');

--- a/server/server.js
+++ b/server/server.js
@@ -19,11 +19,11 @@ MiniEventEmitter.mixin(Server);
 // Public API
 
 // Attach to a http server
-Server.prototype.attach = function(http_server, configuration) {
+Server.prototype.attach = function(httpServer, configuration) {
   this.configuration = configuration;
   Client.dataTTLSet(this.configuration.clientDataTTL);
   Core.Persistence.setConfig(configuration);
-  Core.Persistence.connect(this._setup.bind(this, http_server));
+  Core.Persistence.connect(this._setup.bind(this, httpServer));
 };
 
 // Destroy empty resource
@@ -52,7 +52,7 @@ Server.prototype.terminate = function(done) {
 
 var VERSION_CLIENT_DATASTORE = '0.13.1';
 
-Server.prototype._setup = function(http_server) {
+Server.prototype._setup = function(httpServer) {
   var engine = DefaultEngineIO,
       engineConf;
 
@@ -73,8 +73,8 @@ Server.prototype._setup = function(http_server) {
                 configuration.engineio.conf.path : 'default';
   }
 
-  this.server = engine.attach(http_server, engineConf);
   this.server.on('connection', this._onSocketConnection.bind(this));
+  this.socketServer = engine.attach(httpServer, engineConf);
 
   logging.debug('#server - start ' + new Date().toString());
   this.emit('ready');

--- a/tests/lib/radar.js
+++ b/tests/lib/radar.js
@@ -9,7 +9,7 @@ var http = require('http'),
     Minilog = require('minilog'),
     logger = require('minilog')('lib_radar'),
     formatter = require('./formatter.js'),
-    radar, http_server, serverStarted = false;
+    radar, httpServer, serverStarted = false;
 
 if (process.env.verbose) {
   var minilogPipe = Minilog;
@@ -81,7 +81,7 @@ var Service = {};
 
 Service.start = function(configuration, callback) {
   logger.debug('creating radar', configuration);
-  http_server = http.createServer(p404);
+  httpServer = http.createServer(p404);
   PresenceManager.userTimeout = 1000;
   Sentry.expiry = 4000;
   PresenceManager.autoPubTimeout = 4000;
@@ -89,8 +89,8 @@ Service.start = function(configuration, callback) {
   radar = new Radar.server();
   radar.once('ready', function() {
     logger.debug('radar ready');
-    http_server.listen(configuration.port, function() {
-      logger.debug('http_server listening on', configuration.port);
+    httpServer.listen(configuration.port, function() {
+      logger.debug('httpServer listening on', configuration.port);
       serverStarted = true;
       Persistence.delWildCard('*',function() {
         logger.info('Persistence cleared');
@@ -98,13 +98,13 @@ Service.start = function(configuration, callback) {
       });
     });
   });
-  radar.attach(http_server, configuration);
+  radar.attach(httpServer, configuration);
 };
 
 Service.stop = function(arg, callback){
   logger.info("stop");
-  http_server.on('close', function() {
-    logger.info("http_server closed");
+  httpServer.on('close', function() {
+    logger.info("httpServer closed");
     if (serverStarted) {
       clearTimeout(serverTimeout);
       logger.info("Calling callback, close event");
@@ -116,13 +116,13 @@ Service.stop = function(arg, callback){
     radar.terminate(function() {
       logger.info("radar terminated");
       if (!serverStarted) {
-        logger.info("http_server terminated");
+        logger.info("httpServer terminated");
         callback();
       }
       else {
-        logger.info("closing http_server");
-        logger.info('connections left', http_server._connections);
-        var val = http_server.close();
+        logger.info("closing httpServer");
+        logger.info('connections left', httpServer._connections);
+        var val = httpServer.close();
         serverTimeout = setTimeout(function() {
           // Failsafe, because server.close does not always
           // throw the close event within time.

--- a/tests/message_list.unit.test.js
+++ b/tests/message_list.unit.test.js
@@ -127,7 +127,7 @@ describe('For a message list', function() {
   describe('unsubscribing', function() {
     it('renews expiry for maxPersistence', function(done) {
       var message_list = new MessageList('aab', Radar, { policy : { cache : true, maxPersistence : 24 * 60 * 60 } });
-      message_list.parent = { destroyResource: function() {} };
+      message_list.server = { destroyResource: function() {} };
       FakePersistence.expire = function(name, expiry) {
         assert.equal(expiry, 24 * 60 * 60);
         setTimeout(done,1);

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -14,7 +14,7 @@ describe('given a presence resource',function() {
     broadcast: function() { },
     terminate: function() { },
     destroyResource: function() {},
-    server: {
+    socketServer: {
       clients: { }
     }
   };
@@ -258,8 +258,8 @@ describe('given a presence resource',function() {
           local.push(data);
         };
 
-        Server.server.clients[client.id] = client;
-        Server.server.clients[client2.id] = client2;
+        Server.socketServer.clients[client.id] = client;
+        Server.socketServer.clients[client2.id] = client2;
         messages = {};
         client.send = function(msg) {
           (messages[client.id] || (messages[client.id] = [])).push(msg);


### PR DESCRIPTION
Server is being called in different places, with different meanings. 

This PR renames all server/parent mentions to more meaningful names:

* Server.prototype.server to Server.prototype.socketServer.
* Rename Resource.prototype.parent to Resource.prototype.server
* http_server to httpServer.

## Steps to merge

 :+1: of the team

## References

* Jira link: https://zendesk.atlassian.net/browse/RADAR-516

## Risks

Low.

/cc @zendesk/zendesk-radar 