### PR TITLE
Add rate limiting to prevent client abuse

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,10 @@
+{
+  "globals"   : {
+    "describe"   : false,
+    "it"         : false,
+    "before"     : false,
+    "beforeEach" : false,
+    "after"      : false,
+    "afterEach"  : false
+  }
+}

--- a/core/rate_limiter.js
+++ b/core/rate_limiter.js
@@ -1,0 +1,110 @@
+var logging = require('minilog')('radar:rate_limiter');
+
+var RateLimiter = function(limit) {
+ this._limit = limit;
+ this._resources = {
+   id: {},
+   name: {}
+ };
+};
+
+RateLimiter.prototype.add = function(id, name) {
+  if (!this._isNewResource(id, name)) {
+    return false;
+  }
+
+  if (this.isAboveLimit(id)) {
+    logging.warn('rate limiting client: ' + id + ' name: ' + name);
+    return false;
+  }
+
+  this._add(id, name);
+
+  return true;
+};
+
+RateLimiter.prototype.remove = function(id, name) {
+  delete this._resources.id[id][name];
+  delete this._resources.name[name][id];
+};
+
+RateLimiter.prototype.isAboveLimit = function(id) {
+  return this.count(id) >= this._limit;
+};
+
+RateLimiter.prototype.countAll = function() {
+  var counts = {}, self = this;
+
+  Object.keys(this._resources.id).forEach(function(id) {
+    counts[id] = self.count(id);
+  });
+
+  return counts;
+};
+
+RateLimiter.prototype.count = function(id) {
+  var resources = this._getResourcesByType('id', id);
+  return (resources ? Object.keys(resources).length : 0);
+};
+
+RateLimiter.prototype.removeById = function(id) {
+  this._removeByType('id', 'name', id);
+};
+
+RateLimiter.prototype.removeByName = function(name) {
+  this._removeByType('name', 'id', name);
+};
+
+RateLimiter.prototype._removeByType = function(type1, type2, key) {
+  this._deepRemove(type2, key, this._resources[type1][key], this._getResourcesByType);
+  delete this._resources[type1][key];
+};
+
+RateLimiter.prototype.inspect = function() {
+  return this._resources;
+};
+
+RateLimiter.prototype._add = function(id, name) {
+  this._addByType('id', id, name);
+  this._addByType('name', name, id);
+  return true;
+};
+
+RateLimiter.prototype._addByType = function(type, key1, key2) {
+  var resources = this._getResourcesByType(type, key1);
+
+  if (!resources) {
+    resources = this._initResourcesByType(type, key1);
+  }
+
+  resources[key2] = 1;
+};
+
+RateLimiter.prototype._getResourcesByType = function (type, key) {
+  return this._resources[type][key];
+};
+
+RateLimiter.prototype._initResourcesByType = function (type, key) {
+  var resource = this._resources[type][key] = {};
+  return resource;
+};
+
+RateLimiter.prototype._isNewResource = function(id, name) {
+  var resources = this._getResourcesByType('id', id);
+
+  return !(resources && Object.keys(resources).indexOf(name) !== -1);
+};
+
+RateLimiter.prototype._deepRemove = function(type, key, results, lookup) {
+  var self = this;
+
+  if (results && Object.keys(results).length > 0) {
+    Object.keys(results).forEach(function(result) {
+      var keys = lookup.call(self, type, result);
+
+      if (keys) { delete keys[key]; }
+    });
+  }
+};
+
+module.exports = RateLimiter;

--- a/tests/client.rate_limit.test.js
+++ b/tests/client.rate_limit.test.js
@@ -1,0 +1,75 @@
+var common = require('./common.js'),
+    assert = require('assert'),
+    Tracker = require('callback_tracker'),
+    PresenceMessage = require('./lib/assert_helper.js').PresenceMessage,
+    radar, client;
+
+describe('The Server', function() {
+  var p;
+  before(function(done) {
+    radar = common.spawnRadar();
+    radar.sendCommand('start', common.configuration, done);
+  });
+
+  after(function(done) {
+    common.stopRadar(radar, done);
+  });
+
+  beforeEach(function(done) {
+    p = new PresenceMessage('dev', 'limited1');
+    var track = Tracker.create('beforeEach', done);
+    client = common.getClient('dev', 123, 0, { name: 'tester' }, track('client 1 ready'));
+  });
+
+  afterEach(function() {
+    p.teardown();
+
+    client.presence('limited1').set('offline').removeAllListeners();
+    client.dealloc('test');
+  });
+
+  describe('given a limited presence type', function() {
+
+    it('should not allow subscription after a certain limit', function(done) {
+      var success = false;
+
+      client.on('err', function(message) {
+        assert.equal(message.op, 'err');
+        assert.equal(message.value, 'rate limited');
+        success = true;
+      });
+
+      client.presence('limited1').on(p.notify).subscribe(function(message) {
+        p.for_client(client).assert_ack_for_subscribe(message);
+        client.presence('limited2').subscribe();
+      });
+
+      setTimeout(function() {
+        assert(success, 'Client did not receive an err message');
+        done();
+      }, 1000);
+    });
+
+    it('should handle decrement on unsubscribe ', function(done) {
+      client.presence('limited1').subscribe(function() {
+        client.presence('limited2').subscribe();
+        // Already received the err. 
+        
+        client.presence('limited1').unsubscribe(function() {
+          client.presence('limited1').subscribe(function() { done(); });
+        });
+      });
+    });
+  
+    it.skip('should reset rate on client disconnect', function(done) {
+      client.presence('limited1').subscribe(function() {
+        client.presence('limited2').subscribe();
+        // Already received the err. 
+        client.dealloc('test');
+        // we need to find a way to test client disconnect and reconnect. 
+        done();
+      });
+    });
+  });
+});
+

--- a/tests/lib/radar.js
+++ b/tests/lib/radar.js
@@ -29,52 +29,61 @@ function p404(req, res) {
 
 
 Type.add([
-    {// For client.auth.test
-      name: 'client_auth',
-      expression: /^message:\/client_auth\/disabled$/,
-      type: 'MessageList',
-      policy: { cache: true, maxAgeSeconds: 30 },
-      authProvider: {
-        authorize: function() { return false; }
-      }
-    },
-    {
-      name: 'client_auth',
-      expression: /^message:\/client_auth\/enabled$/,
-      type: 'MessageList',
-      authProvider: {
-        authorize: function() { return true; }
-      }
-    },
-    {// For client.message.test
-      name: 'cached_chat',
-      expression: /^message:\/dev\/cached_chat\/(.+)/,
-      type: 'MessageList',
-      policy: { cache: true, maxAgeSeconds: 30 }
-    },
-    {// For client.presence.test
-      name: 'short_expiry',
-      expression: /^presence:\/dev\/test/,
-      type: 'Presence',
-      policy: { userExpirySeconds : 1 }
-    },
-    {
-      name: 'short_stream',
-      expression: /^stream:\/dev\/short_stream\/(.+)/,
-      type: 'Stream',
-      policy: { maxLength: 2 }
-    },
-    {
-      name: 'uncached_stream',
-      expression: /^stream:\/dev\/uncached_stream\/(.+)/,
-      type: 'Stream',
-      policy: { maxLength: 0 }
-    },
+  {// For client.auth.test
+    name: 'client_auth',
+    expression: /^message:\/client_auth\/disabled$/,
+    type: 'MessageList',
+    policy: { cache: true, maxAgeSeconds: 30 },
+    authProvider: {
+      authorize: function() { return false; }
+    }
+  },
+  {
+    name: 'client_auth',
+    expression: /^message:\/client_auth\/enabled$/,
+    type: 'MessageList',
+    authProvider: {
+      authorize: function() { return true; }
+    }
+  },
+  {// For client.message.test
+    name: 'cached_chat',
+    expression: /^message:\/dev\/cached_chat\/(.+)/,
+    type: 'MessageList',
+    policy: { cache: true, maxAgeSeconds: 30 }
+  },
+  {// For client.presence.test
+    name: 'short_expiry',
+    expression: /^presence:\/dev\/test/,
+    type: 'Presence',
+    policy: { userExpirySeconds : 1 }
+  },
+  {
+    name: 'short_stream',
+    expression: /^stream:\/dev\/short_stream\/(.+)/,
+    type: 'Stream',
+    policy: { maxLength: 2 }
+  },
+  {
+    name: 'uncached_stream',
+    expression: /^stream:\/dev\/uncached_stream\/(.+)/,
+    type: 'Stream',
+    policy: { maxLength: 0 }
+  },
   {
     name: 'general control',
     type: 'Control',
     expression: /^control:/
-  }
+  },
+  {// For client.presence.test
+    name: 'limited',
+    expression: /^presence:\/dev\/limited/,
+    type: 'Presence',
+    policy: { 
+      maxLength: 0, // FIXME: policy requires maxLength. It should not. 
+      limit: 1
+    }
+  },
 ]);
 
 var Service = {};

--- a/tests/rate_limiter.test.js
+++ b/tests/rate_limiter.test.js
@@ -1,0 +1,63 @@
+var assert = require('assert'),
+    RateLimiter = require('../core/rate_limiter.js'),
+    limit = 1,
+    clientId = '1', 
+    clientId2 = '2', 
+    namePrefix = 'presence://thing/',
+    name = namePrefix + '1',
+    rateLimiter;
+
+describe('rateLimiter', function() {
+  beforeEach(function() {
+    rateLimiter = new RateLimiter(limit);
+  });
+
+  it('add', function(){
+    assert.equal(rateLimiter.count(clientId), 0);
+    rateLimiter.add(clientId, name);
+    assert.equal(rateLimiter.count(clientId), 1);
+  });
+
+  it('remove', function(){
+    rateLimiter.add(clientId, name);
+    rateLimiter.remove(clientId, name);
+    assert.equal(rateLimiter.count(clientId), 0);
+  });
+
+  it('isAboveLimit', function(){
+    rateLimiter.add(clientId, name);
+    assert(rateLimiter.isAboveLimit(clientId));
+  });
+
+  it ('duplicates should not count', function() {
+    rateLimiter.add(clientId, name);  
+    assert( ! rateLimiter.add(clientId, name) );
+    assert.equal(rateLimiter.count(clientId), 1);
+  });
+
+  it('removing by id', function() {
+    rateLimiter.add(clientId, name);
+    rateLimiter.add(clientId2, name);
+
+    assert.equal(rateLimiter.count(clientId), 1);
+    assert.equal(rateLimiter.count(clientId2), 1);
+
+    rateLimiter.removeById(clientId);
+
+    assert.equal(rateLimiter.count(clientId), 0);
+    assert.equal(rateLimiter.count(clientId2), 1);
+  });
+
+  it('removing by name', function() {
+    rateLimiter.add(clientId, name);
+    rateLimiter.add(clientId2, name);
+
+    assert.equal(rateLimiter.count(clientId), 1);
+    assert.equal(rateLimiter.count(clientId2), 1);
+
+    rateLimiter.removeByName(name);
+
+    assert.equal(rateLimiter.count(clientId), 0);
+    assert.equal(rateLimiter.count(clientId2), 0);
+  });
+});


### PR DESCRIPTION
Add rate limiting by scope type. Disabled by default. 

/cc @zendesk/zendesk-radar

### Steps to merge

:+1: of the team

### Risks

Low: It's extending the existing api, but no client is using it already.