### PR TITLE
Prevent rate limiter from trying to remove for none existent clients

### DIFF
--- a/core/rate_limiter.js
+++ b/core/rate_limiter.js
@@ -29,9 +29,11 @@ RateLimiter.prototype.add = function(id, name) {
 };
 
 RateLimiter.prototype.remove = function(id, name) {
-  delete this._resources.id[id][name];
-  delete this._resources.name[name][id];
-  this.emit('rate:remove', this._stateForId(id, name));
+  if (this._resources.id[id] && this._resources.name[name]) {
+    delete this._resources.id[id][name];
+    delete this._resources.name[name][id];
+    this.emit('rate:remove', this._stateForId(id, name));
+  }
 };
 
 RateLimiter.prototype.isAboveLimit = function(id) {

--- a/tests/rate_limiter.test.js
+++ b/tests/rate_limiter.test.js
@@ -24,6 +24,11 @@ describe('rateLimiter', function() {
     assert.equal(rateLimiter.count(clientId), 0);
   });
 
+  it('remove before adding', function(){
+    rateLimiter.remove(clientId, name);
+    assert.equal(rateLimiter.count(clientId), 0);
+  });
+
   it('isAboveLimit', function(){
     rateLimiter.add(clientId, name);
     assert(rateLimiter.isAboveLimit(clientId));


### PR DESCRIPTION
Addresses this issue: https://zendesk.airbrake.io/projects/88776/groups/1450211911461012641/notices/1450211911461012640

### Steps to merge

:+1: from the @zendesk/zendesk-radar team

### Risks

None
