### PR TITLE
Emit Server and Resource events

### DIFF
--- a/core/lib/resource.js
+++ b/core/lib/resource.js
@@ -85,6 +85,8 @@ Resource.prototype.redisIn = function(data) {
       socket.send(data);
     }
   });
+
+  this.emit('message:outgoing', data);
 };
 
 // Return a socket reference; eio server hash is "clients", not "sockets"

--- a/core/lib/resource.js
+++ b/core/lib/resource.js
@@ -1,4 +1,5 @@
 var Persistence = require('persistence'),
+    MiniEventEmitter = require('miniee'),
     logging = require('minilog')('radar:resource');
 
 /*
@@ -44,6 +45,7 @@ function Resource(name, server, options, default_options) {
   this.options = recursiveMerge({}, options || {}, default_options || {});
 }
 
+MiniEventEmitter.mixin(Resource);
 Resource.prototype.type = 'default';
 
 // Add a subscriber (Engine.io socket)
@@ -111,6 +113,7 @@ Resource.prototype.handleMessage = function(socket, message) {
     case 'publish':
     case 'push':
       this[message.op](socket, message);
+      this.emit('message:incoming', message);
       break;
     default:
       logging.error('#resource - Unknown message.op, ignoring', message, socket && socket.id);

--- a/core/lib/resources/presence/index.js
+++ b/core/lib/resources/presence/index.js
@@ -232,6 +232,8 @@ Presence.prototype.broadcast = function(message, except) {
         'explicit:', (socket && socket.id && self.subscribers[socket.id]), self.name);
     }
   });
+
+  this.emit('message:outgoing', message);
 };
 
 Presence.prototype.fullRead = function(callback) {

--- a/server/server.js
+++ b/server/server.js
@@ -39,7 +39,7 @@ Server.prototype.destroyResource = function(name) {
   if (this._rateLimiters[messageType.name]) {
     this._rateLimiters[messageType.name].removeByName(name);
   }
-
+  
   delete this.resources[name];
   delete this.subs[name];
   logging.info('#redis - unsubscribe', name);
@@ -328,6 +328,7 @@ Server.prototype._getResource = function(message, messageType) {
 Server.prototype._storeResource = function(resource) {
   if (!this.resources[resource.name]) {
     this.resources[resource.name] = resource;
+    this.emit('resource:new', resource);
   }
 };
 

--- a/tests/common.js
+++ b/tests/common.js
@@ -114,5 +114,16 @@ module.exports = {
       }).once('ready', done).alloc('test');
       return client;
   },
-  configuration: configuration
+  configuration: configuration,
+
+  // Create an in-process radar server, not a child process. 
+  createRadarServer: function() {
+  
+    var notFound = function p404(req, res){ },
+        httpServer = http.createServer(notFound);
+
+    radarServer = new RadarServer();
+    radarServer.attach(httpServer, configuration);
+    return radarServer;
+  }
 };

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -461,3 +461,46 @@ describe('given a presence resource',function() {
     });
   });
 });
+
+describe('a presence resource', function() {
+  describe('emitting messages', function() {
+    beforeEach(function() {
+      radarServer = Common.createRadarServer();
+    });
+
+    it('should emit incomming messages', function(done) {
+      var subscribeMessage = { op: 'subscribe', to: 'presence:/z1/test/ticket/1' };
+
+      radarServer.on('resource:new', function(resource) {
+        resource.on('message:incoming', function(message) {
+          assert.equal(message.to, subscribeMessage.to);
+          done()
+        });
+      });
+
+      setTimeout(function() {
+        radarServer._processMessage({}, subscribeMessage);
+      }, 100);
+    });
+
+    it('should emit outgoing messages', function(done) {
+      var count = 0,
+          setMessage = { op: 'set', to: 'presence:/z1/test/ticket/1', value: 'online' },
+          subscribeMessage = { op: 'subscribe', to: 'presence:/z1/test/ticket/1' },
+          socketOne = { id: 1, send: function(m) { } },
+          socketTwo = { id: 2, send: function(m) { } };
+
+      radarServer.on('resource:new', function(resource) {
+        resource.on('message:outgoing', function(message) {
+          count++;
+          if (count === 2) { done() };
+        });
+      });
+
+      setTimeout(function() {
+        radarServer._processMessage(socketOne, subscribeMessage);
+        radarServer._processMessage(socketTwo, setMessage);
+      }, 100);
+    });
+  });
+});

--- a/tests/server.unit.test.js
+++ b/tests/server.unit.test.js
@@ -1,21 +1,15 @@
-var http = require('http'),
+var common = require('./common.js'),
     assert = require('assert'),
-    Persistence = require('persistence'),
-    RadarServer = new require('../index.js').server,
-    configuration = require('../configurator.js').load({persistence: true}),
     subscribeMessage = {
       op: 'subscribe',
       to: 'presence:/z1/test/ticket/1'
     },
-    notFound = function p404(req, res){ },
-    httpServer, radarServer, socket;
+    radarServer, socket;
 
 describe('given a server',function() {
 
   beforeEach(function() {
-    httpServer = http.createServer(notFound);
-    radarServer = new RadarServer();
-    radarServer.attach(httpServer, configuration);
+    radarServer = common.createRadarServer();
     socket = {};
   });
 

--- a/tests/server.unit.test.js
+++ b/tests/server.unit.test.js
@@ -1,0 +1,52 @@
+var http = require('http'),
+    assert = require('assert'),
+    Persistence = require('persistence'),
+    RadarServer = new require('../index.js').server,
+    configuration = require('../configurator.js').load({persistence: true}),
+    subscribeMessage = {
+      op: 'subscribe',
+      to: 'presence:/z1/test/ticket/1'
+    },
+    notFound = function p404(req, res){ },
+    httpServer, radarServer, socket;
+
+describe('given a server',function() {
+
+  beforeEach(function() {
+    httpServer = http.createServer(notFound);
+    radarServer = new RadarServer();
+    radarServer.attach(httpServer, configuration);
+    socket = {};
+  });
+
+  it('should emit resource:new when allocating a new reosurce', function(done) {
+    radarServer.on('resource:new', function(resource) {
+      assert.equal(resource.name, subscribeMessage.to);
+      done();
+    });
+
+    setTimeout(function() {
+      radarServer._processMessage(socket, subscribeMessage);
+    }, 100);
+
+  });
+
+  it('should emit resource:new when allocating a new resource, but not on subsequent calls', function(done) {
+    var called = false;
+
+    radarServer.on('resource:new', function(resource) {
+      assert(!called);
+      called = true;
+
+      setImmediate(function() {
+        radarServer._processMessage(socket, subscribeMessage);
+      });
+    });
+
+    setTimeout(function() {
+      radarServer._processMessage(socket, subscribeMessage);
+      setTimeout(done, 1800);
+    }, 100);
+
+  });
+});


### PR DESCRIPTION
Emit the following events, to allow cleaner connection/usage from external components. 

* RadarServer - 'resource:new': Every time a resource is allocated on the server instance. 
* Resource - 'message:incoming': Every time a message is handled by a resource.
* Presence - 'message:outgoing': Every time a message is broadcasted by a Presence resource.

### TODO

* Implemented 'message:outgoing' for all other resources

### Steps to merge

:+1: of the team

/cc @zendesk/zendesk-radar