### PR TITLE
Refactor Sentry (rejected) (see individual PRs)

### DIFF
--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -228,15 +228,6 @@ PresenceManager.prototype.processRedisEntry = function(message, callback) {
   callback = callback || function() {};
 
   if (this.isOnline(message)) {
-    if (!message.sentry) {
-      logging.info('#presence - #autopub - received online message without sentry',
-                                                              message, this.scope);
-      message.sentry = userId + '.' + socketId;
-
-      // Publish fake entry, autopub will renew it
-      sentry._keepAlive({ name: message.sentry, save: false });
-    }
-
     if (!sentry.isSentryDown(message.sentry)) {
       logging.debug('#presence - processRedisEntry: sentry.isSentryDown false',
                                               message.sentry, this.scope);

--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -204,10 +204,6 @@ PresenceManager.prototype.isOnline = function(message) {
   return (message.online && message.sentry);
 };
 
-PresenceManager.prototype.isExpired = function(message) {
-  return (message.online && !message.sentry);
-};
-
 PresenceManager.prototype.processRedisEntry = function(message, callback) {
   var store = this.store,
       manager = this,
@@ -236,15 +232,6 @@ PresenceManager.prototype.processRedisEntry = function(message, callback) {
     }
     callback();
   } else {
-    if (this.isExpired(message)) {
-      logging.info('#autopub - received online message - expired', message,
-                                                                this.scope);
-
-      // Orphan autopub redis entry: silently remove from redis
-      Persistence.deleteHash(this.scope, userId + '.' + socketId);
-      message.explicit = false;
-    }
-
     this.handleOffline(socketId, userId, userType, message.explicit);
     callback();
   }

--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -91,7 +91,6 @@ PresenceManager.prototype.sentryDownForClient = function(socketId) {
     online: false,
     explicit: false
   };
-  this.stampExpiration(message);
 
   // Process directly
   this.processRedisEntry(message);
@@ -120,12 +119,6 @@ PresenceManager.prototype.destroy = function() {
 
   delete this.store;
 };
-
-// For backwards compatibility, add a '.at' to message
-PresenceManager.prototype.stampExpiration = function(message) {
-  message.at = Date.now() + PresenceManager.messageExpiry;
-};
-
 // FIXME: Method signature is getting unmanageable.  
 PresenceManager.prototype.addClient = function(socketId, userId, userType,
                                                       userData, clientData, callback) {
@@ -142,10 +135,8 @@ PresenceManager.prototype.addClient = function(socketId, userId, userType,
     online: true,
     sentry: this.sentry.name
   };
-  
-  if (clientData) { message.clientData = clientData; }
 
-  this.stampExpiration(message);
+  if (clientData) { message.clientData = clientData; }
 
   // We might need the details before we actually do a store.add
   this.store.cacheAdd(socketId, message);
@@ -168,8 +159,7 @@ PresenceManager.prototype.removeClient = function(socketId, userId, userType, ca
     online: false,
     explicit: true
   };
-  this.stampExpiration(message);
-
+  
   Persistence.deleteHash(this.scope, userId + '.' + socketId);
   Persistence.publish(this.scope, message, callback);
 };
@@ -208,7 +198,6 @@ PresenceManager.prototype._implicitDisconnect = function(socketId, userId,
     online: false,
     explicit: false
   };
-  this.stampExpiration(message);
 
   Persistence.deleteHash(this.scope, userId + '.' + socketId);
   Persistence.publish(this.scope, message, callback);

--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -228,13 +228,13 @@ PresenceManager.prototype.processRedisEntry = function(message, callback) {
   callback = callback || function() {};
 
   if (this.isOnline(message)) {
-    if (!sentry.isSentryDown(message.sentry)) {
-      logging.debug('#presence - processRedisEntry: sentry.isSentryDown false',
+    if (!sentry.isDown(message.sentry)) {
+      logging.debug('#presence - processRedisEntry: sentry.isDown false',
                                               message.sentry, this.scope);
       manager.clearExpiry(userId);
       store.add(socketId, userId, userType, message);
     } else {
-      logging.debug('#presence - processRedisEntry: sentry.isSentryDown true',
+      logging.debug('#presence - processRedisEntry: sentry.isDown true',
                                               message.sentry, this.scope);
 
       // Orphan redis entry: silently remove from redis then remove from store

--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -216,15 +216,14 @@ PresenceManager.prototype.processRedisEntry = function(message, callback) {
   callback = callback || function() {};
 
   if (this.isOnline(message)) {
-    if (!sentry.isDown(message.sentry)) {
-      logging.debug('#presence - processRedisEntry: sentry.isDown false',
+    var isDown = sentry.isDown(message.sentry);
+
+    logging.debug('#presence - processRedisEntry: sentry.isDown', isDown, 
                                               message.sentry, this.scope);
+    if (!isDown) {
       manager.clearExpiry(userId);
       store.add(socketId, userId, userType, message);
     } else {
-      logging.debug('#presence - processRedisEntry: sentry.isDown true',
-                                              message.sentry, this.scope);
-
       // Orphan redis entry: silently remove from redis then remove from store
       // implicitly.
       Persistence.deleteHash(this.scope, userId + '.' + socketId);

--- a/core/lib/resources/presence/readme.md
+++ b/core/lib/resources/presence/readme.md
@@ -84,15 +84,6 @@ A little map: .unsubscribe() (either from socket close or client message) -> man
 
 on user expiry timeout -> store.removeUserIfEmpty() (if user exists and no clients) -> user_removed -> user_offline message.
 
-Backward compatibility
-=====================
-
-There are two things done to bring limited compatibility with earlier versions of radar server. This is intended for testing new version servers amongst a cluster of old servers for a limited period, as well as do rolling updates.
-
-1. Message expiration: Old radar server depends on values of message.at being concurrent. If message.at is too old, the entries are cleaned up or clients removed. To keep them concurrent, the server auto-publishes them every 15 seconds with current time as message.at. The new server sets message.at to one hour in the future so that messages are not expired and there is no need for autopublishes. The drawback here is that server death will not be visible to the old servers until one hour.
-
-2. Filtering message.at and keeping fake sentries: This is a way for the new servers to work with the old servers' autopublish system and message expiration using message.at. If we receive an online message without a sentry stamp, we look for message.at. if the message.at is concurrent (within 25 seconds from now), we add a fake sentry to our sentry-store. This sentry's id is client-id.user-id which is makes it unique for the client/user combination. Each autopublish message received renews the validity of this sentry within our store. Note that these fake sentry values are not published to redis, and this still works correctly because autopubs go to all interested servers. If we stop receiving autopubs, we stop renewing the sentry, and eventually the sentry will be detected as 'down' after a predictable amount of time. This will cause an implicit disconnect for the client.
-
 Known issues
 ============
 

--- a/core/lib/resources/presence/sentry.js
+++ b/core/lib/resources/presence/sentry.js
@@ -5,9 +5,9 @@ var _ = require('underscore'),
     redisSentriesKey = 'sentry:/radar';
 
 var defaultOptions = {
-  DEFAULT_EXPIRY_OFFSET: 4000,
-  REFRESH_INTERVAL: 3500,
-  CHECK_INTERVAL: 10000
+  DEFAULT_EXPIRY_OFFSET: 60000,
+  REFRESH_INTERVAL: 10000,
+  CHECK_INTERVAL: 30000
 };
 
 var parseJSON = function(message) {

--- a/core/lib/resources/presence/sentry.js
+++ b/core/lib/resources/presence/sentry.js
@@ -93,7 +93,7 @@ Sentry.prototype.isDown = function(name) {
 
   if (isSentryDown) {
     var expiration = messageExpiration(lastMessage); 
-    var text = (expiration) ? expiration + '/' + Sentry.expiry : 'not-present';
+    var text = expiration ? expiration + '/' + this._defaultExpiryOffset : 'not-present';
     logging.debug('#presence - #sentry isDown', name, isSentryDown, text);
   }
 

--- a/core/lib/resources/presence/sentry.js
+++ b/core/lib/resources/presence/sentry.js
@@ -87,7 +87,7 @@ Sentry.prototype.sentryNames = function() {
   return Object.keys(this.sentries);
 };
 
-Sentry.prototype.isSentryDown = function(name) {
+Sentry.prototype.isDown = function(name) {
   var lastMessage = this.sentries[name];
   var isDown = messageIsExpired(lastMessage);
 
@@ -166,7 +166,7 @@ Sentry.prototype._loadAndCleanUpSentries = function(callback) {
 
     repliesKeys.forEach(function(name) {
       self.sentries[name] = replies[name];
-      if (self.isSentryDown(name)) {
+      if (self.isDown(name)) {
         self._purgeSentry(name);
       }
     });

--- a/server/server.js
+++ b/server/server.js
@@ -70,9 +70,10 @@ Server.prototype._setup = function(httpServer, configuration) {
 
   this.subscriber.on('message', this._handlePubSubMessage.bind(this));
 
-  Core.Resources.Presence.sentry.start();
-  Core.Resources.Presence.sentry.setMaxListeners(0);
-  Core.Resources.Presence.sentry.setHostPort(hostname, configuration.port);
+  Core.Resources.Presence.sentry.start({
+    host: hostname,
+    port: configuration.port
+  });
 
   if (configuration.engineio) {
     engine = configuration.engineio.module;

--- a/server/server.js
+++ b/server/server.js
@@ -65,10 +65,11 @@ var VERSION_CLIENT_STOREDATA = '0.13.1';
 Server.prototype._setup = function(httpServer, configuration) {
   var engine = DefaultEngineIO, engineConf;
 
-  configuration = configuration || {};
   this.subscriber = Core.Persistence.pubsub();
 
   this.subscriber.on('message', this._handlePubSubMessage.bind(this));
+
+  configuration = configuration || {};
 
   if (configuration.engineio) {
     engine = configuration.engineio.module;

--- a/server/server.js
+++ b/server/server.js
@@ -89,6 +89,13 @@ Server.prototype._setup = function(httpServer, configuration) {
 };
 
 Server.prototype._setupSentry = function(configuration) {
+  if (this.sentry) {
+    logging.warn('trying to initialize an already initialized sentry: ' + this.sentry.name);
+    return;
+  }
+
+  this.sentry = Core.Resources.Presence.sentry;
+
   var sentryOptions = {
         host: hostname,
         port: configuration.port
@@ -98,7 +105,7 @@ Server.prototype._setupSentry = function(configuration) {
     _.extend(sentryOptions, configuration.sentry); 
   }
 
-  Core.Resources.Presence.sentry.start(sentryOptions);
+  this.sentry.start(sentryOptions);
 };
 
 Server.prototype._onSocketConnection = function(socket) {

--- a/tests/client.presence.remote.test.js
+++ b/tests/client.presence.remote.test.js
@@ -110,38 +110,6 @@ describe('given a client and a server,', function() {
         setTimeout(done, 10);
       });
 
-      describe('from legacy servers, ', function() {
-        it('should emit online if message is not expired', function(done) {
-
-          // Remove sentry and add autopub level expiry
-          delete sentry.name;
-
-          presenceManager.stampExpiration = function(message) {
-            message.at = Date.now();
-          };
-          var validate = function() {
-            p.assert_message_sequence([ 'online', 'client_online' ]);
-            done();
-          };
-          presenceManager.addClient('abc', 100, 2, { name: 'tester' });
-
-          p.fail_on_more_than(2);
-          p.on(2, function() {
-            setTimeout(validate, 10);
-          });
-        });
-        it('should ignore expired messages', function(done) {
-
-          // Remove sentry and add autopub level expiry
-          delete sentry.name;
-          presenceManager.stampExpiration = function(message) {
-            message.at = Date.now() - 5000;
-          };
-          presenceManager.addClient('abc', 100, 2, { name: 'tester' });
-          p.fail_on_any_message();
-          setTimeout(done, 10);
-        });
-      });
     });
     describe('for incoming offline messages,', function() {
       beforeEach(function(done) {
@@ -342,34 +310,6 @@ describe('given a client and a server,', function() {
           });
         });
       });
-      describe('with legacy messages, ', function() {
-        it('should include clients with unexpired entries', function(done) {
-          var callback = false;
-          var validate = function() {
-            p.for_online_clients(clients.abc, clients.def, clients.klm)
-              .assert_onlines_received();
-            assert.ok(callback);
-            done();
-          };
-
-          delete sentry.name;
-          presenceManager.stampExpiration = function(message) {
-            message.at = Date.now();
-          };
-
-          presenceManager.addClient('klm', 400, 2, { name: 'tester4' }, function() {
-            client.presence('test').on(p.notify).sync({ version: 2 }, function(message) {
-              p.for_online_clients(clients.abc, clients.def, clients.klm)
-                .assert_sync_v2_response(message);
-              callback = true;
-            });
-
-            p.fail_on_more_than(6);
-            p.on(6, function() {
-              setTimeout(validate, 10);
-            });
-          });
-        });
 
         it('should ignore clients with expired entries', function(done) {
           var callback = false;

--- a/tests/client.presence.remote.test.js
+++ b/tests/client.presence.remote.test.js
@@ -6,33 +6,12 @@ var common = require('./common.js'),
     PresenceManager = require('../core/lib/resources/presence/presence_manager.js'),
     Client = require('radar_client').constructor,
     EE = require('events').EventEmitter,
-    PresenceMessage = require('./lib/assert_helper.js').PresenceMessage,
-    Sentry = require('../core/lib/resources/presence/sentry.js');
+    AssertHelper = require('./lib/assert_helper.js'),
+    PresenceMessage = AssertHelper.PresenceMessage,
+    presenceManagerForSentry = AssertHelper.presenceManagerForSentry;
 
 var radar, client, client2,
     p, testSentry, presenceManager, track;
-
-var presenceManagerForSentry = function(name, options, callback) {
-  var tempSentry = new Sentry(name),
-      pm = new PresenceManager('presence:/dev/test', {}, tempSentry);
-
-  options = options || {};
-  
-  if (typeof(options) !== 'object') {
-    callback = options;
-    options = {};
-  }
-
-  if (!options.dead) {
-    tempSentry.start(options, function() {
-      callback(pm);
-      tempSentry.stop();
-    });
-  } else {
-    tempSentry._keepAlive(options); 
-    callback(pm);
-  }
-};
 
 describe('given a client and a server,', function() {
   before(function(done) {
@@ -52,7 +31,7 @@ describe('given a client and a server,', function() {
 
   beforeEach(function(done) {
     notifications = [];
-    testSentry = new Sentry('test-sentry');
+    testSentry = AssertHelper.newTestSentry('test-sentry');
     presenceManager = new PresenceManager('presence:/dev/test',{}, testSentry);
     p = new PresenceMessage('dev', 'test');
     p.client = { clientId: 'abc', userId: 100, userType: 2, userData: { name: 'tester' } };

--- a/tests/client.presence.sentry.test.js
+++ b/tests/client.presence.sentry.test.js
@@ -15,24 +15,10 @@ describe('given a client and a server,', function() {
   var p, 
       sentry = new Sentry('test-sentry', assertHelper.SentryDefaults),
       presenceManager = new PresenceManager('presence:/dev/test', {}, sentry),
-      publish_client_online = function(client) {
+      publishClientOnline = function(client) {
         presenceManager.addClient(client.clientId, client.userId, client.userType, client.userData);
       };
   
-  var publish_autopub = function(client) {
-    delete sentry.name;
-    var original = presenceManager.stampExpiration;
-    presenceManager.stampExpiration = function(m) {
-      m.at = Date.now();
-    };
-    publish_client_online(client);
-    // Restore
-    sentry.name = 'test-sentry';
-
-    // Restore from prototype
-    delete presenceManager.stampExpiration;
-  };
-
   before(function(done) {
     common.startPersistence(function() {
       radar = common.spawnRadar();
@@ -96,7 +82,7 @@ describe('given a client and a server,', function() {
           done();
         };
 
-        publish_client_online(p.client);
+        publishClientOnline(p.client);
         setTimeout(function() {
           sentry.stop();
           p.on(4, validate);
@@ -111,7 +97,7 @@ describe('given a client and a server,', function() {
           done();
         };
 
-        publish_client_online(p.client);
+        publishClientOnline(p.client);
         setTimeout(function() {
           // Renew sentry
           sentry._keepAlive();

--- a/tests/client.presence.sentry.test.js
+++ b/tests/client.presence.sentry.test.js
@@ -6,16 +6,18 @@ var common = require('./common.js'),
     PresenceManager = require('../core/lib/resources/presence/presence_manager.js'),
     Client = require('radar_client').constructor,
     EE = require('events').EventEmitter,
-    PresenceAssert = require('./lib/assert_helper.js').PresenceMessage,
+    PresenceMessage = require('./lib/assert_helper.js').PresenceMessage,
     Sentry = require('../core/lib/resources/presence/sentry.js'),
     radar, client, client2;
 
 describe('given a client and a server,', function() {
-  var p, sentry = new Sentry('test-sentry');
-  var presenceManager = new PresenceManager('presence:/dev/test', {}, sentry);
-  var publish_client_online = function(client) {
-    presenceManager.addClient(client.clientId, client.userId, client.userType, client.userData);
-  };
+  var p, 
+      sentry = new Sentry('test-sentry'),
+      presenceManager = new PresenceManager('presence:/dev/test', {}, sentry),
+      publish_client_online = function(client) {
+        presenceManager.addClient(client.clientId, client.userId, client.userType, client.userData);
+      };
+  
   var publish_autopub = function(client) {
     delete sentry.name;
     var original = presenceManager.stampExpiration;
@@ -45,13 +47,15 @@ describe('given a client and a server,', function() {
   });
 
   beforeEach(function(done) {
-    p = new PresenceAssert('dev', 'test');
+    p = new PresenceMessage('dev', 'test');
     p.client = { userId: 100, clientId: 'abc', userData: { name: 'tester' }, userType: 2 };
 
-    // Set ourselves alive
-    sentry.publishKeepAlive();
+    
     var track = Tracker.create('beforeEach', done);
-    client = common.getClient('dev', 123, 0, { name: 'tester' }, track('client 1 ready'));
+    // Set ourselves alive
+    sentry.start(function(){
+      client = common.getClient('dev', 123, 0, { name: 'tester' }, track('client 1 ready'));
+    });
   });
 
   afterEach(function(done) {
@@ -70,11 +74,17 @@ describe('given a client and a server,', function() {
 
     describe('for incoming online messages,', function() {
       it('should emit offlines if sentry times out', function(done) {
-        this.timeout(8000);
+        
+        this.timeout(18000);
+
         var validate = function() {
           var ts = p.times;
-          p.assert_message_sequence(['online', 'client_online',
-                                'client_implicit_offline', 'offline']);
+          p.assert_message_sequence([
+            'online',
+            'client_online',
+            'client_implicit_offline',
+            'offline'
+          ]);
 
           // sentry expiry = 4000
           assert.ok((ts[2] - ts[1]) >= 3000, 'sentry expiry was '+(ts[2] - ts[1]));
@@ -86,7 +96,11 @@ describe('given a client and a server,', function() {
         };
 
         publish_client_online(p.client);
-        p.on(4, validate);
+        setTimeout(function() {
+          sentry.stop();
+          p.on(4, validate);
+        }, 1000);
+        
       });
 
       it('should still be online if sentry is alive', function(done) {
@@ -99,7 +113,7 @@ describe('given a client and a server,', function() {
         publish_client_online(p.client);
         setTimeout(function() {
           // Renew sentry
-          sentry.publishKeepAlive();
+          sentry._keepAlive();
         }, 2000);
 
         p.fail_on_more_than(2);

--- a/tests/client.presence.sentry.test.js
+++ b/tests/client.presence.sentry.test.js
@@ -6,13 +6,14 @@ var common = require('./common.js'),
     PresenceManager = require('../core/lib/resources/presence/presence_manager.js'),
     Client = require('radar_client').constructor,
     EE = require('events').EventEmitter,
-    PresenceMessage = require('./lib/assert_helper.js').PresenceMessage,
+    assertHelper = require('./lib/assert_helper.js'),
+    PresenceMessage = assertHelper.PresenceMessage,
     Sentry = require('../core/lib/resources/presence/sentry.js'),
     radar, client, client2;
 
 describe('given a client and a server,', function() {
   var p, 
-      sentry = new Sentry('test-sentry'),
+      sentry = new Sentry('test-sentry', assertHelper.SentryDefaults),
       presenceManager = new PresenceManager('presence:/dev/test', {}, sentry),
       publish_client_online = function(client) {
         presenceManager.addClient(client.clientId, client.userId, client.userType, client.userData);

--- a/tests/client.presence.sentry.test.js
+++ b/tests/client.presence.sentry.test.js
@@ -107,51 +107,6 @@ describe('given a client and a server,', function() {
           setTimeout(validate, 5000);
         });
       });
-
-      describe('from legacy servers, ', function() {
-        it('should emit offlines if autopub does not arrive', function(done) {
-          this.timeout(8000);
-          var validate = function() {
-            var ts = p.times;
-            p.assert_message_sequence(['online', 'client_online',
-                                      'client_implicit_offline', 'offline']);
-
-            // sentry expiry = 4000
-            assert.ok((ts[2] - ts[1]) >= 3000, 'sentry expiry was '+(ts[2] - ts[1]));
-            assert.ok((ts[2] - ts[1]) < 6000, 'sentry expiry was '+(ts[2] - ts[1]));
-            // user expiry = 1000
-            assert.ok((ts[3] - ts[2]) >= 900, 'user expiry was '+(ts[3] - ts[2]));
-            assert.ok((ts[3] - ts[2]) < 1900, 'user expiry was '+(ts[3] - ts[2]));
-            done();
-          };
-
-          // Simulate autopub
-          publish_autopub(p.client);
-
-          p.once(4, validate);
-        });
-
-        it('should still be online if sentry is alive', function(done) {
-          this.timeout(6000);
-          var validate = function() {
-            p.assert_message_sequence(['online', 'client_online']);
-            done();
-          };
-
-          // Simulate autopub
-          publish_autopub(p.client);
-
-          setTimeout(function() {
-            // Send an autopub message
-            publish_autopub(p.client);
-          }, 2000);
-
-          p.fail_on_more_than(2);
-          p.once(2, function() {
-            setTimeout(validate, 5000);
-          });
-        });
-      });
     });
   });
 });

--- a/tests/client.presence.test.js
+++ b/tests/client.presence.test.js
@@ -208,7 +208,8 @@ describe('given two clients and a presence resource', function() {
       });
 
       it('should send online notification only once for multiple set(online), unless updated clientData', function(done) {
-        var clientData = { data: 2 }
+        var clientData = { data: 2 };
+
         // Subscribe online with client 2
         client2.presence('test').on(p.notify)
           .subscribe(function() {

--- a/tests/lib/assert_helper.js
+++ b/tests/lib/assert_helper.js
@@ -536,3 +536,8 @@ StreamMessage.prototype.assert_sync_response = StreamMessage.prototype.assert_ge
 StreamMessage.prototype.fail_on_more_than = PresenceMessage.prototype.fail_on_more_than;
 module.exports.PresenceMessage = PresenceMessage;
 module.exports.StreamMessage = StreamMessage;
+module.exports.SentryDefaults = {
+  defaultExpiryOffset: 4000,
+  refreshInterval: 3500,
+  checkInterval: 10000
+};

--- a/tests/lib/assert_helper.js
+++ b/tests/lib/assert_helper.js
@@ -159,14 +159,17 @@ PresenceMessage.prototype.assert_client_implicit_offline =  function(message) {
 };
 
 PresenceMessage.prototype.assert_message_sequence = function(list, from) {
-  var i, messages = this.notifications.slice(from);
+  var i, method, args, 
+      messages = this.notifications.slice(from);
+
   assert.equal(messages.length, list.length, 'mismatch '+list+' in messages received : '+JSON.stringify(messages));
 
   for(i = 0; i < messages.length; i++) {
     if (typeof(list[i]) === 'object') {
-      var method = 'assert_' + list[i][0], args = list[i][1];
+      method = 'assert_' + list[i][0];
+      args = list[i][1];
     } else {
-      var method = 'assert_'+list[i], args;
+      method = 'assert_'+list[i];
     }
 
     this[method].call(this, messages[i], args);

--- a/tests/lib/radar.js
+++ b/tests/lib/radar.js
@@ -96,7 +96,6 @@ Service.start = function(configuration, callback) {
 
   radar = new Radar.server();
   radar.once('ready', function() {
-    logger.debug('radar ready');
     httpServer.listen(configuration.port, function() {
       logger.debug('httpServer listening on', configuration.port);
       serverStarted = true;

--- a/tests/lib/radar.js
+++ b/tests/lib/radar.js
@@ -9,6 +9,7 @@ var http = require('http'),
     Minilog = require('minilog'),
     logger = require('minilog')('lib_radar'),
     formatter = require('./formatter.js'),
+    assertHelper = require('./assert_helper.js'),
     radar, httpServer, serverStarted = false;
 
 if (process.env.verbose) {
@@ -26,7 +27,6 @@ function p404(req, res) {
   res.statusCode = 404;
   res.end('404 Not Found');
 }
-
 
 Type.add([
   {// For client.auth.test
@@ -91,7 +91,10 @@ Service.start = function(configuration, callback) {
   logger.debug('creating radar', configuration);
   httpServer = http.createServer(p404);
   PresenceManager.userTimeout = 1000;
-  Sentry.expiry = 4000;
+  
+  // Add sentry defaults for testing. 
+  configuration.sentry = assertHelper.SentryDefaults;
+
   PresenceManager.autoPubTimeout = 4000;
 
   radar = new Radar.server();

--- a/tests/presence.remote.test.js
+++ b/tests/presence.remote.test.js
@@ -1,24 +1,24 @@
 var assert = require('assert'),
     Persistence = require('persistence'),
     Presence = require('../index.js').core.Presence,
-    Common = require('./common.js');
-
-var Server = {
-  broadcast: function() { },
-  server: {
-    clients: { }
-  }
-};
-var readHashAll = Persistence.readHashAll;
+    Common = require('./common.js'),
+    readHashAll = Persistence.readHashAll,
+    Server = {
+      broadcast: function() { },
+      server: {
+        clients: { }
+      }
+    };
 
 exports['given a presence monitor'] = {
 
   beforeEach: function(done) {
     var self = this;
+    Persistence.readHashAll = readHashAll;
     Common.startPersistence(function() {
       Presence.sentry.start();
       self.presence = new Presence('aaa', Server, {});
-      Persistence.readHashAll = readHashAll;
+      
       done();
     });
   },
@@ -226,7 +226,7 @@ exports['given a presence monitor'] = {
     presence.manager.on('user_offline', function(userId, userType) {
       removed[userId] = userType;
     });
-
+    
     this.presence.fullRead(function(online) {
       assert.deepEqual({ }, removed);
       assert.deepEqual({ 200: 2, 201: 4 }, added);

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -58,7 +58,6 @@ describe('given a presence resource',function() {
         assert.equal(2, m.userType);
         assert.equal(true, m.online);
         assert.equal(undefined, m.clientData);
-        assert.ok(m.at > Date.now()+59*60000);
         presence.redisIn(m);
         published = true;
       };
@@ -78,7 +77,6 @@ describe('given a presence resource',function() {
         assert.equal(1, m.userId);
         assert.equal(2, m.userType);
         assert.equal(false, m.online);
-        assert.ok(m.at > Date.now()+59*60000);
         published = true;
         presence.redisIn(m);
       };
@@ -96,7 +94,6 @@ describe('given a presence resource',function() {
         assert.equal(2, m.userType);
         assert.equal(true, m.online);
         assert.equal(clientData, m.clientData);
-        assert.ok(m.at > Date.now()+59*60000);
         published = true;
         presence.redisIn(m);
       };
@@ -130,7 +127,6 @@ describe('given a presence resource',function() {
         assert.equal(1, userId);
         assert.equal(2, userType);
         assert.equal(true, online);
-        assert.ok(m.at > Date.now()+59*60000);
         calls++;
         presence.redisIn(m);
       };
@@ -297,8 +293,6 @@ describe('given a presence resource',function() {
 
         assert.equal(remote.length, 1);
         // A client_offline should be sent for CID 1
-        assert.ok(remote[0].at > Date.now()+59*60000);
-        delete remote[0].at;
         assert.deepEqual(remote[0], { userId: 1,
           userType: 2,
           clientId: client.id,
@@ -310,8 +304,6 @@ describe('given a presence resource',function() {
 
         // There should be a client_offline notification for CID 2
         assert.equal(remote.length, 2);
-        assert.ok(remote[1].at > Date.now()+59*60000);
-        delete remote[1].at;
         assert.deepEqual(remote[1], { userId: 1,
           userType: 2,
           clientId: client2.id,
@@ -351,7 +343,6 @@ describe('given a presence resource',function() {
         assert.equal(remote[0].online, false);
         assert.equal(remote[0].userId, 1);
         assert.equal(remote[0].clientId, client.id);
-        assert.ok(remote[0].at > Date.now()+59*60000);
 
         presence.unsubscribe(client2);
 
@@ -360,7 +351,6 @@ describe('given a presence resource',function() {
         assert.equal(remote[1].userId, 1);
         assert.equal(remote[1].clientId, client2.id);
         assert.equal(remote[1].online, false);
-        assert.ok(remote[1].at > Date.now()+59*60000);
 
         // Check local broadcast
         assert.equal(local.length, 2);
@@ -396,7 +386,6 @@ describe('given a presence resource',function() {
         assert.equal(remote[0].online, false);
         assert.equal(remote[0].userId, 1);
         assert.equal(remote[0].clientId, client.id);
-        assert.ok(remote[0].at > Date.now()+59*60000);
 
         presence.set(client2, { key: 1, type: 2, value: 'offline' } );
 
@@ -474,7 +463,7 @@ describe('a presence resource', function() {
       radarServer.on('resource:new', function(resource) {
         resource.on('message:incoming', function(message) {
           assert.equal(message.to, subscribeMessage.to);
-          done()
+          done();
         });
       });
 
@@ -493,7 +482,7 @@ describe('a presence resource', function() {
       radarServer.on('resource:new', function(resource) {
         resource.on('message:outgoing', function(message) {
           count++;
-          if (count === 2) { done() };
+          if (count === 2) { done(); }
         });
       });
 

--- a/tests/radar_api.test.js
+++ b/tests/radar_api.test.js
@@ -178,7 +178,7 @@ exports['Radar api tests'] = {
       PresenceManager.setBackend(FakePersistence);
       var fakeSentry = {
         name: 'server1',
-        isSentryDown: function() {
+        isDown: function() {
          return false;
         },
         on: function() {}

--- a/tests/radar_api.test.js
+++ b/tests/radar_api.test.js
@@ -172,14 +172,18 @@ exports['Radar api tests'] = {
       FakePersistence.readHashAll = function(scope, callback) {
         callback(messages[scope]);
       };
+
+      FakePersistence.deleteHash = function(scope, callback) {};
+
       PresenceManager.setBackend(FakePersistence);
       var fakeSentry = {
         name: 'server1',
-        isValid: function() {
-         return true;
+        isSentryDown: function() {
+         return false;
         },
         on: function() {}
       };
+
       Presence.sentry = fakeSentry;
       done();
     },

--- a/tests/sentry.unit.test.js
+++ b/tests/sentry.unit.test.js
@@ -48,16 +48,16 @@ describe('a Server Entry (Sentry)', function() {
     sentry.start(done);
   });
 
-  describe('isSentryDown', function() {
+  describe('isDown', function() {
     it('initially, it should be down', function() {
       sentry = newSentry();
-      assert.equal(sentry.isSentryDown(sentry.name), true);
+      assert.equal(sentry.isDown(sentry.name), true);
     });
 
     it('after start, it should be up', function() {
       sentry = newSentry();
       sentry.start(function() {
-        assert.equal(sentry.isSentryDown(sentry.name), false);
+        assert.equal(sentry.isDown(sentry.name), false);
       });
     });
 

--- a/tests/sentry.unit.test.js
+++ b/tests/sentry.unit.test.js
@@ -1,0 +1,141 @@
+var assert = require('assert'),
+    Tracker = require('callback_tracker'),
+    Sentry = require('../core/lib/resources/presence/sentry.js'),
+    Persistence = require('persistence'),
+    configuration = require('../configurator.js').load({persistence: true}),
+    _ = require('underscore'),
+    currentSentry = 0,
+    sentry, sentryOne, sentryTwo, sentryThree, sentries = [];
+
+function newSentry(options) {
+  var name = 'sentry-' + currentSentry++,
+      defaults = { 
+        refreshInterval: 100,
+        checkInterval: 200,
+        defaultExpiryOffset: 200
+      };
+
+  return new Sentry(name, _.extend(defaults, (options || {}))); 
+}
+
+function assertSentriesKnowEachOther(sentries, done) {
+  var sentryNames = sentries.map(function(s) { return s.name; });
+
+  sentries.forEach(function(sentry) {
+    _.mapObject(sentry.sentries, function(message) {
+      assert(_.indexOf(sentryNames, message.name) >= -1);
+    });
+  });
+
+  if (done) { done(); }
+}
+
+describe('a Server Entry (Sentry)', function() {
+  before(function(done) {
+    Persistence.setConfig(configuration.persistence);
+    Persistence.connect(done);
+  });
+
+  afterEach(function(done) {
+    Persistence.redis().del('sentry:/radar', function() {
+      if (sentry) { sentry.stop(done); } else { done(); }
+      sentries.forEach(function(s) { s.stop(); });
+    });
+  });
+
+  it('start with callback', function(done) {
+    sentry = newSentry();
+    sentry.start(done);
+  });
+
+  describe('isSentryDown', function() {
+    it('initially, it should be down', function() {
+      sentry = newSentry();
+      assert.equal(sentry.isSentryDown(sentry.name), true);
+    });
+
+    it('after start, it should be up', function() {
+      sentry = newSentry();
+      sentry.start(function() {
+        assert.equal(sentry.isSentryDown(sentry.name), false);
+      });
+    });
+
+  });
+
+  describe('keep alive', function() {
+    it('should generate a valid sentry message', function() {
+      sentry = newSentry();
+
+      sentry.start(function() {
+        assert.equal(sentry.sentries.length, 1);
+        assert.equal(sentry.name, sentry.sentries[0].name);
+      });
+    }); 
+  });
+
+  describe('check & clean up', function() {
+    beforeEach(function(done) {
+      sentryOne = newSentry();
+      sentryTwo = newSentry();
+      sentries = [ sentryOne, sentryTwo ];
+
+      sentryOne.start(function() {
+        sentryTwo.start(done);
+      });
+    });
+
+    it('after start, the sentries should know about each other', function(done) {
+      var checkSentriesKnowEachOther = function() {
+        sentries.forEach(function(s) {
+          assert.equal(Object.keys(s.sentries).length, 2);
+        });
+        done();
+      };
+
+      setTimeout(checkSentriesKnowEachOther, 200);
+    });
+
+    it('after a down, and after check, sentries should clean up', function(done) {
+      var checkForSentryTwoGone = function() {
+        setTimeout(function() {
+          assert.equal(sentryOne.sentries[sentryTwo.name], undefined);
+          done();
+        }, 300);
+      };
+
+      sentryTwo.stop(checkForSentryTwoGone);
+    });
+  });
+
+  describe('complex scenario, with more than two sentries, when one dies', function() {
+    it('all remaining sentries should do proper cleanup', function(done) {
+      sentryOne = newSentry({   checkInterval: 10});
+      sentryTwo = newSentry({   checkInterval: 20}); // It's important that sentryTwo is slower. 
+      sentryThree = newSentry();
+      sentries = [ sentryOne, sentryTwo, sentryThree ];
+
+      var stopAndAssert = function() {
+        // stop one
+        sentryThree.stop(function() {
+          setTimeout(function() {
+            // assert existing sentries no longer know sentryThree. 
+            assert.equal(sentryOne.sentries[sentryThree.name], undefined);
+            assert.equal(sentryTwo.sentries[sentryThree.name], undefined);
+            done();
+          }, 300);
+        });
+      };
+
+      // start everything...
+      sentryOne.start(function() {
+        sentryTwo.start(function() {
+          sentryThree.start(function() {
+            // assert ideal state, every one know each other
+            assertSentriesKnowEachOther(sentries, stopAndAssert);
+          });
+        });
+      });
+    });  
+  });
+});

--- a/util.js
+++ b/util.js
@@ -1,0 +1,20 @@
+var lut = []; 
+
+for (var i=0; i<256; i++) {
+  lut[i] = (i<16?'0':'')+(i).toString(16); 
+}
+
+module.exports = {
+  uuid: function() {
+  
+    var d0 = Math.random()*0xffffffff|0;
+    var d1 = Math.random()*0xffffffff|0;
+    var d2 = Math.random()*0xffffffff|0;
+    var d3 = Math.random()*0xffffffff|0;
+
+    return lut[d0&0xff]+lut[d0>>8&0xff]+lut[d0>>16&0xff]+lut[d0>>24&0xff]+'-'+
+      lut[d1&0xff]+lut[d1>>8&0xff]+'-'+lut[d1>>16&0x0f|0x40]+lut[d1>>24&0xff]+'-'+
+      lut[d2&0x3f|0x80]+lut[d2>>8&0xff]+'-'+lut[d2>>16&0xff]+lut[d2>>24&0xff]+
+      lut[d3&0xff]+lut[d3>>8&0xff]+lut[d3>>16&0xff]+lut[d3>>24&0xff];
+  }
+};


### PR DESCRIPTION
(DON'T USE)

* Stop relying on Redis pubsub for notifications. Most changes are inferred based on time. 
* Emit 'up' event. 
* Remove support for .at field on messages (related to legacy servers).

### Steps to merge

:+1: of the team

/cc @zendesk/zendesk-radar

### Risks

Medium.