### PR TITLE
Attempt to fix reconnect brittle test 

### DIFF
--- a/tests/client.reconnect.test.js
+++ b/tests/client.reconnect.test.js
@@ -42,12 +42,14 @@ describe('When radar server restarts', function() {
   it('reestablishes presence', function(done) {
     this.timeout(4000);
     var verifySubscriptions = function() {
-      client2.presence('restore').get(function(message) {
-        assert.equal('get', message.op);
-        assert.equal('presence:/test/restore', message.to);
-        assert.deepEqual({ 123 : 0 }, message.value);
-        done();
-      });
+      setTimeout(function() {
+        client2.presence('restore').get(function(message) {
+          assert.equal('get', message.op);
+          assert.equal('presence:/test/restore', message.to);
+          assert.deepEqual({ 123 : 0 }, message.value);
+          done();
+        });
+      }, 1000); // let's wait a little
     };
 
     client.presence('restore').set('online', function() {


### PR DESCRIPTION
Attempt to fix reconnect brittle test by waiting a little longer after radar restart.

### Steps to merge

:+1: of the team

/cc @zendesk/zendesk-radar

### Risks

None.