### PR TITLE
Stamp incoming and outgoing messages

### DIFF
--- a/core/lib/resource.js
+++ b/core/lib/resource.js
@@ -1,6 +1,7 @@
 var Persistence = require('persistence'),
     MiniEventEmitter = require('miniee'),
-    logging = require('minilog')('radar:resource');
+    logging = require('minilog')('radar:resource'),
+    Stamper = require('../stamper.js');
 
 /*
 
@@ -77,12 +78,17 @@ Resource.prototype.unsubscribe = function(socket, message) {
 // Send to Engine.io sockets
 Resource.prototype.redisIn = function(data) {
   var self = this;
+  
+  Stamper.stamp(data);
+
   logging.info('#'+this.type, '- incoming from #redis', this.name, data, 'subs:',
                                           Object.keys(this.subscribers).length );
 
   Object.keys(this.subscribers).forEach(function(socketId) {
     var socket = self.socketGet(socketId);
+    
     if (socket && socket.send) {
+      data.stamp.clientId = socket.id;
       socket.send(data);
     }
   });

--- a/core/stamper.js
+++ b/core/stamper.js
@@ -18,7 +18,8 @@ module.exports = {
       message.stamp = {
         id: uuid.v4(),
         clientId: clientId,
-        sentryId: sentryName
+        sentryId: sentryName,
+        timestamp: new Date().toJSON()
       };
     }
     

--- a/core/stamper.js
+++ b/core/stamper.js
@@ -1,0 +1,28 @@
+var uuid = require('uuid'),
+    logging = require('minilog')('radar:stamper'),
+    sentryName;
+
+module.exports = {
+  setup: function(name) {
+    sentryName = name;
+  },
+
+  stamp: function(message, clientId) {
+    if (!sentryName) { 
+      logging.error('run Stamper.setup() before trying to stamp');
+    }
+ 
+    if (message.stamp && clientId) {
+      message.stamp.clientId = clientId; 
+    } else {
+      message.stamp = {
+        id: uuid.v4(),
+        clientId: clientId,
+        sentryId: sentryName
+      };
+    }
+    
+    return message;
+  }
+};
+

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,6 @@
 var _ = require('underscore'),
     MiniEventEmitter = require('miniee'),
     Core = require('../core'),
-    uuid = require('uuid'),
     Type = Core.Type,
     logging = require('minilog')('radar:server'),
     hostname = require('os').hostname(),
@@ -9,7 +8,8 @@ var _ = require('underscore'),
     Semver = require('semver'),
     Client = require('../client/client.js'),
     Pauseable = require('pauseable'),
-    RateLimiter = require('../core/rate_limiter.js');
+    RateLimiter = require('../core/rate_limiter.js'),
+    Stamper = require('../core/stamper.js');
 
 function Server() {
   this.socketServer = null;
@@ -110,6 +110,8 @@ Server.prototype._setupSentry = function(configuration) {
   if (configuration.sentry) { 
     _.extend(sentryOptions, configuration.sentry); 
   }
+
+  Stamper.setup(this.sentry.name);
 
   this.sentry.start(sentryOptions);
 };
@@ -406,13 +408,7 @@ Server.prototype._initClient = function (socket, message) {
 };
 
 Server.prototype._stampMessage = function(socket, message) {
-  message.stamp = {
-    id: uuid.v4(),
-    clientId: socket.id,
-    sentryId: this.sentry.name
-  };
-
-  return message;
+  return Stamper.stamp(message, socket.id);
 };
 
 function _parseJSON(data) {

--- a/tests/lib/assert_helper.js
+++ b/tests/lib/assert_helper.js
@@ -90,6 +90,7 @@ PresenceMessage.prototype.assert_stamp = function(stamp) {
   assert(stamp);
   assert(stamp.id);
   assert(stamp.sentryId);
+  assert(stamp.timestamp);
 };
 
 // user online:

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -293,6 +293,10 @@ describe('given a presence resource',function() {
 
         assert.equal(remote.length, 1);
         // A client_offline should be sent for CID 1
+
+        // Remove stamp, it makes no sense to test those
+        delete remote[0].stamp;
+
         assert.deepEqual(remote[0], { userId: 1,
           userType: 2,
           clientId: client.id,
@@ -302,8 +306,12 @@ describe('given a presence resource',function() {
 
         presence.set(client2, { key: 1, type: 2, value: 'offline' } );
 
+        // Remove stamp, it makes no sense to test those
+        delete remote[1].stamp;
+
         // There should be a client_offline notification for CID 2
         assert.equal(remote.length, 2);
+
         assert.deepEqual(remote[1], { userId: 1,
           userType: 2,
           clientId: client2.id,
@@ -311,6 +319,8 @@ describe('given a presence resource',function() {
           explicit: true
         });
 
+        // Remove stamp, it makes no sense to test those
+        delete local[0].stamp;
         // Check local broadcast
         assert.equal(local.length, 3);
         // There should be a client_offline notification for CID 1
@@ -319,6 +329,9 @@ describe('given a presence resource',function() {
           explicit: true,
           value: { userId: 1, clientId: client.id }
         });
+
+        // Remove stamp, it makes no sense to test those
+        delete local[1].stamp;
         // There should be a client_offline notification for CID 2
         assert.deepEqual(local[1],{ to: 'aaa',
           op: 'client_offline',
@@ -326,6 +339,8 @@ describe('given a presence resource',function() {
           value: { userId: 1, clientId: client2.id }
         });
         // There should be a broadcast for a offline notification for UID 1
+        // Remove stamp, it makes no sense to test those
+        delete local[2].stamp;
         assert.deepEqual(local[2],  { to: 'aaa', op: 'offline', value: { 1: 2 } });
         assert.deepEqual(local[2].value, { 1: 2 });
 

--- a/tests/server.unit.test.js
+++ b/tests/server.unit.test.js
@@ -66,6 +66,9 @@ describe('given a server',function() {
         };
 
     radarServer.on('resource:new', function(resource) {
+      
+      resource.subscribe(socket.id, { ack: 1 });
+
       resource.on('message:incoming', function(incomingMessage) {
         assert(incomingMessage.stamp.id !== undefined);
         assert.equal(incomingMessage.stamp.clientId, socket.id);

--- a/tests/stamper.test.js
+++ b/tests/stamper.test.js
@@ -1,0 +1,41 @@
+
+var assert = require('assert'),
+    Stamper = require('../core/stamper.js'),
+    sentryName = 'theSentryName',
+    clientId = 'clientId';
+
+Stamper.setup('theSentryName');
+
+describe('a Stamper service', function() {
+  it('adds a stamp object to objects', function() {
+    var message = {}; 
+   
+    Stamper.stamp(message, clientId);
+
+    assert(message.stamp);
+    assert(message.stamp.id);
+    assert.equal(message.stamp.clientId, clientId);
+    assert.equal(message.stamp.sentryId, sentryName);
+  });
+
+  it('allows optional client id', function() {
+    var message = {}; 
+   
+    Stamper.stamp(message);
+
+    assert(message.stamp);
+    assert(message.stamp.id);
+    assert.equal(message.stamp.clientId, undefined);
+    assert.equal(message.stamp.sentryId, sentryName);
+  });
+
+  it('does not override id if present', function() {
+    var message = {stamp: { id: 1 } }; 
+   
+    Stamper.stamp(message, clientId);
+
+    assert.equal(message.stamp.id, 1);
+    assert.equal(message.stamp.clientId, clientId);
+  });
+});
+


### PR DESCRIPTION
This PR makes radar stamp **incoming** and **outgoing** messages with id (uuid), sentry name, and socket id. This information becomes relevant when is extracted to logs or when it's being exported for post processing. 

I decided to not include the (client|socket).id when emitting outgoing events, because that would mean emitting one event for each message per client, per server. So, because of that, the server only emits one outgoing event per server, per message. 

**Do not confuse emit with sending events to the clients. That functionality remains intact.**

### Steps to merge

:+1: of the team

/cc @zendesk/zendesk-radar

### Risks

None.