### PR TITLE
Changes so radar_client integration tests work for new radar_client

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "radar_client": "*",
+    "radar_client": "git://github.com/zendesk/radar_client.git#pobrien/feature_message_protocol_v2_branch1",
     "simple_sentinel": "*"
   },
   "scripts": {

--- a/tests/client.auth.test.js
+++ b/tests/client.auth.test.js
@@ -30,7 +30,8 @@ describe('auth test', function() {
 
   describe('if type is disabled', function() {
     it('subscribe fails and emits err', function(done) {
-      client.on('err', function(message) {
+      client.on('err', function(response) {
+        var message = response.getMessage();
         assert.ok(message.origin);
         assert.equal(message.origin.op, 'subscribe');
         assert.equal(message.origin.to, 'message:/client_auth/disabled');
@@ -45,7 +46,8 @@ describe('auth test', function() {
 
     it('publish fails, emits err and is not persisted', function(done) {
       // Cache policy true for this type
-      client.on('err', function(message) {
+      client.on('err', function(response) {
+        var message = response.getMessage();
         assert.ok(message.origin);
         assert.equal(message.origin.op, 'publish');
         assert.equal(message.origin.to, 'message:/client_auth/disabled');

--- a/tests/client.rate_limit.test.js
+++ b/tests/client.rate_limit.test.js
@@ -33,7 +33,8 @@ describe('The Server', function() {
     it('should not allow subscription after a certain limit', function(done) {
       var success = false;
 
-      client.on('err', function(message) {
+      client.on('err', function(response) {
+        var message = response.getMessage();
         assert.equal(message.op, 'err');
         assert.equal(message.value, 'rate limited');
         success = true;

--- a/tests/lib/assert_helper.js
+++ b/tests/lib/assert_helper.js
@@ -363,6 +363,8 @@ PresenceMessage.prototype.assert_ack_for = function(type, message) {
   var expected = { to: this.scope };
   var ackNumber = message.ack;
   delete message.ack;
+  var options = message.options;
+  delete message.options;
 
   switch(type) {
     case 'set_online':
@@ -384,6 +386,7 @@ PresenceMessage.prototype.assert_ack_for = function(type, message) {
 
   // Restore
   message.ack = ackNumber;
+  message.options = options;
 };
 
 PresenceMessage.prototype.assert_ack_for_set_online = function(message) {
@@ -445,6 +448,8 @@ StreamMessage.prototype.assert_ack_for = function(type, message, resource, actio
   var expected = { to: this.scope };
   var ackNumber = message.ack;
   delete message.ack;
+  var options = message.options;
+  delete message.options;
 
   switch(type) {
     case 'subscribe':
@@ -467,6 +472,7 @@ StreamMessage.prototype.assert_ack_for = function(type, message, resource, actio
 
   // Restore
   message.ack = ackNumber;
+  message.options = options;
 };
 
 StreamMessage.prototype.assert_ack_for_subscribe = PresenceMessage.prototype.assert_ack_for_subscribe;


### PR DESCRIPTION
Development-only dependency changes to integration tests with radar_client in radar so that radar tests will pass with the new radar_client.

Once a new radar_client is released, the package.json reference will need to be reverted to * from the current branch reference. 

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-481

### Risks
 - None.  This is a dev-only dependency;  the interface between *radar* and *radar_client* is not changing