### PR TITLE
Remove loadData on server-side client init

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -402,10 +402,7 @@ Server.prototype._sendErrorMessage = function(socket, value, origin) {
 
 // Initialize the current client
 Server.prototype._initClient = function (socket, message) {
-  var client = Client.create(message);
-  if (client) {
-    client.loadData(this._replayMessagesFromClient.bind(this, socket, client));
-  }
+  Client.create(message);
 };
 
 Server.prototype._stampMessage = function(socket, message) {


### PR DESCRIPTION
Remove *loadData* from the server-side client init.  Fix some *storeData* code that was broken (but which had no effect as the server code was not enabled by the client.)  Log subscription and presence counts for a given client in *storeData*.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: 

### Risks
 - None