### PR TITLE
Stop including alive attribute on sentry keep alive messages

### DIFF
--- a/core/lib/resources/presence/sentry.js
+++ b/core/lib/resources/presence/sentry.js
@@ -149,7 +149,6 @@ Sentry.prototype._newKeepAliveMessage = function(name, expiration) {
   return {
     name: (name || this.name),
     expiration: (expiration || this._expiryOffsetFromNow()),
-    alive: true,
     host: this.host,
     port: this.port
   };


### PR DESCRIPTION
### Steps to merge

:+1: of the team

/cc @zendesk/zendesk-radar

### Risks

None. Functionality already deprecated. 