### PR TITLE
Replace "name" with "to" for resources

### DIFF
--- a/api/apis/radar.js
+++ b/api/apis/radar.js
@@ -27,9 +27,9 @@ function parseData(response, data, ResourceType) {
     return jsonResponse(response, {});
   }
 
-  var resourceName = ResourceType.prototype.type + ':/' + parameters.accountName + '/' + parameters.scope,
-      options = Type.getByExpression(resourceName),
-      resource = new ResourceType(resourceName, {}, options);
+  var resourceTo = ResourceType.prototype.type + ':/' + parameters.accountName + '/' + parameters.scope,
+      options = Type.getByExpression(resourceTo),
+      resource = new ResourceType(resourceTo, {}, options);
 
   resource.accountName = parameters.accountName;
   resource.scope = parameters.scope;
@@ -51,10 +51,10 @@ function setStatus(req, res, re, data) {
       return jsonResponse(res, {});
     }
 
-    status._set(status.name,
+    status._set(status.to,
       {
         op: 'set',
-        to: status.name,
+        to: status.to,
         key: status.key,
         value: status.value,
       }, status.options.policy || {}, function() {
@@ -83,7 +83,7 @@ function setMessage(req, res, re, data) {
       return jsonResponse(res, {});
     }
 
-    message._publish(message.name, message.options.policy || {},
+    message._publish(message.to, message.options.policy || {},
       {
         op: 'publish',
         to: 'message:/' + message.accountName + '/' + message.scope,
@@ -99,7 +99,7 @@ function getMessage(req, res) {
       message = parseData(res, parts.query, MessageList);
 
   if (message) {
-    message._sync(message.name, message.options.policy || {}, function(replies) {
+    message._sync(message.to, message.options.policy || {}, function(replies) {
       jsonResponse(res, replies);
     });
   }

--- a/core/lib/resource.js
+++ b/core/lib/resource.js
@@ -39,8 +39,8 @@ function recursiveMerge(target) {
   return target;
 }
 
-function Resource(name, server, options, default_options) {
-  this.name = name;
+function Resource(to, server, options, default_options) {
+  this.to = to;
   this.subscribers = {};
   this.server = server; // RadarServer instance
   this.options = recursiveMerge({}, options || {}, default_options || {});
@@ -53,7 +53,7 @@ Resource.prototype.type = 'default';
 Resource.prototype.subscribe = function(socket, message) {
   this.subscribers[socket.id] = true;
 
-  logging.debug('#'+this.type, '- subscribe', this.name, socket.id,
+  logging.debug('#'+this.type, '- subscribe', this.to, socket.id,
                               this.subscribers, message && message.ack);
 
   this.ack(socket, message && message.ack);
@@ -63,13 +63,13 @@ Resource.prototype.subscribe = function(socket, message) {
 Resource.prototype.unsubscribe = function(socket, message) {
   delete this.subscribers[socket.id];
 
-  logging.info('#'+this.type, '- unsubscribe', this.name, socket.id,
+  logging.info('#'+this.type, '- unsubscribe', this.to, socket.id,
                     'subscribers left:', Object.keys(this.subscribers).length);
 
   if (!Object.keys(this.subscribers).length) {
-    logging.info('#'+this.type, '- destroying resource', this.name,
+    logging.info('#'+this.type, '- destroying resource', this.to,
                                           this.subscribers, socket.id);
-    this.server.destroyResource(this.name);
+    this.server.destroyResource(this.to);
   }
 
   this.ack(socket, message && message.ack);
@@ -81,7 +81,7 @@ Resource.prototype.redisIn = function(data) {
   
   Stamper.stamp(data);
 
-  logging.info('#'+this.type, '- incoming from #redis', this.name, data, 'subs:',
+  logging.info('#'+this.type, '- incoming from #redis', this.to, data, 'subs:',
                                           Object.keys(this.subscribers).length );
 
   Object.keys(this.subscribers).forEach(function(socketId) {
@@ -103,7 +103,7 @@ Resource.prototype.socketGet = function (id) {
 
 Resource.prototype.ack = function(socket, sendAck) {
   if (socket && socket.send && sendAck) {
-    logging.debug('#socket - send_ack', socket.id, this.name, sendAck);
+    logging.debug('#socket - send_ack', socket.id, this.to, sendAck);
 
     socket.send({
       op: 'ack',

--- a/core/lib/resources/status.js
+++ b/core/lib/resources/status.js
@@ -8,8 +8,8 @@ var default_options = {
   }
 };
 
-function Status(name, server, options) {
-  Resource.call(this, name, server, options, default_options);
+function Status(to, server, options) {
+  Resource.call(this, to, server, options, default_options);
 }
 
 Status.prototype = new Resource();
@@ -17,29 +17,29 @@ Status.prototype.type = 'status';
 
 // Get status
 Status.prototype.get = function(socket) {
-  var name = this.name;
+  var to = this.to;
 
-  logger.debug('#status - get', this.name, (socket && socket.id));
+  logger.debug('#status - get', this.to, (socket && socket.id));
 
-  this._get(name, function(replies) {
+  this._get(to, function(replies) {
     socket.send({
       op: 'get',
-      to: name,
+      to: to,
       value: replies || {}
     });
   });
 };
 
-Status.prototype._get = function(name, callback) {
-  Persistence.readHashAll(name, callback);
+Status.prototype._get = function(to, callback) {
+  Persistence.readHashAll(to, callback);
 };
 
 Status.prototype.set = function(socket, message) {
   var self = this;
 
-  logger.debug('#status - set', this.name, message, (socket && socket.id));
+  logger.debug('#status - set', this.to, message, (socket && socket.id));
 
-  Status.prototype._set(this.name, message, this.options.policy, function() {
+  Status.prototype._set(this.to, message, this.options.policy, function() {
     self.ack(socket, message.ack);
   });
 };
@@ -58,7 +58,7 @@ Status.prototype._set = function(scope, message, policy, callback) {
 };
 
 Status.prototype.sync = function(socket) {
-  logger.debug('#status - sync', this.name, (socket && socket.id));
+  logger.debug('#status - sync', this.to, (socket && socket.id));
 
   this.subscribe(socket, false);
   this.get(socket);

--- a/core/lib/type.js
+++ b/core/lib/type.js
@@ -29,9 +29,9 @@ var Types = [
   }
 ];
 
-// Get the type by resource name.
-function getByExpression(name) {
-  if (name) {
+// Get the type by resource "to" (aka, full scope)
+function getByExpression(to) {
+  if (to) {
     for (var i = 0, l = Types.length, definition, expression; i < l; ++i) {
       definition = Types[i];
       expression = definition.expression || definition.expr;
@@ -41,13 +41,13 @@ function getByExpression(name) {
         continue;
       }
 
-      if (expression.test && expression.test(name) || expression === name) {
-        logger.debug('#type - found', name);
+      if (expression.test && expression.test(to) || expression === to) {
+        logger.debug('#type - found', to);
         return definition;
       }
     }
   }
-  logger.error('#type - Unable to find a valid type definition for:', name);
+  logger.error('#type - Unable to find a valid type definition for:', to);
 }
 
 module.exports = {

--- a/core/rate_limiter.js
+++ b/core/rate_limiter.js
@@ -5,34 +5,34 @@ var RateLimiter = function(limit) {
  this._limit = limit;
  this._resources = {
    id: {},
-   name: {}
+   to: {}
  };
 };
 
 MiniEventEmitter.mixin(RateLimiter);
 
-RateLimiter.prototype.add = function(id, name) {
-  if (!this._isNewResource(id, name)) {
+RateLimiter.prototype.add = function(id, to) {
+  if (!this._isNewResource(id, to)) {
     return false;
   }
 
   if (this.isAboveLimit(id)) {
-    this.emit('rate:limit', this._stateForId(id, name));
-    logging.warn('rate limiting client: ' + id + ' name: ' + name);
+    this.emit('rate:limit', this._stateForId(id, to));
+    logging.warn('rate limiting client: ' + id + ' to: ' + to);
     return false;
   }
 
-  this._add(id, name);
-  this.emit('rate:add', this._stateForId(id, name));
+  this._add(id, to);
+  this.emit('rate:add', this._stateForId(id, to));
 
   return true;
 };
 
-RateLimiter.prototype.remove = function(id, name) {
-  if (this._resources.id[id] && this._resources.name[name]) {
-    delete this._resources.id[id][name];
-    delete this._resources.name[name][id];
-    this.emit('rate:remove', this._stateForId(id, name));
+RateLimiter.prototype.remove = function(id, to) {
+  if (this._resources.id[id] && this._resources.to[to]) {
+    delete this._resources.id[id][to];
+    delete this._resources.to[to][id];
+    this.emit('rate:remove', this._stateForId(id, to));
   }
 };
 
@@ -57,12 +57,12 @@ RateLimiter.prototype.count = function(id) {
 
 RateLimiter.prototype.removeById = function(id) {
   this.emit('rate:remove_by_id', this._stateForId(id));
-  this._removeByType('id', 'name', id);
+  this._removeByType('id', 'to', id);
 };
 
-RateLimiter.prototype.removeByName = function(name) {
-  this.emit('rate:remove_by_name', this._stateForId(undefined, name));
-  this._removeByType('name', 'id', name);
+RateLimiter.prototype.removeByTo = function(to) {
+  this.emit('rate:remove_by_to', this._stateForId(undefined, to));
+  this._removeByType('to', 'id', to);
 };
 
 RateLimiter.prototype._removeByType = function(type1, type2, key) {
@@ -74,9 +74,9 @@ RateLimiter.prototype.inspect = function() {
   return this._resources;
 };
 
-RateLimiter.prototype._add = function(id, name) {
-  this._addByType('id', id, name);
-  this._addByType('name', name, id);
+RateLimiter.prototype._add = function(id, to) {
+  this._addByType('id', id, to);
+  this._addByType('to', to, id);
   return true;
 };
 
@@ -99,10 +99,10 @@ RateLimiter.prototype._initResourcesByType = function (type, key) {
   return resource;
 };
 
-RateLimiter.prototype._isNewResource = function(id, name) {
+RateLimiter.prototype._isNewResource = function(id, to) {
   var resources = this._getResourcesByType('id', id);
 
-  return !(resources && Object.keys(resources).indexOf(name) !== -1);
+  return !(resources && Object.keys(resources).indexOf(to) !== -1);
 };
 
 RateLimiter.prototype._deepRemove = function(type, key, results, lookup) {
@@ -116,10 +116,10 @@ RateLimiter.prototype._deepRemove = function(type, key, results, lookup) {
     });
   }
 };
-RateLimiter.prototype._stateForId = function(id, name) {
+RateLimiter.prototype._stateForId = function(id, to) {
   return { 
     id: id, 
-    name: name,
+    to: to,
     limit: this._limit,
     count: this.count(id)
   };

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -34,7 +34,7 @@ describe('given a presence resource',function() {
       client2.id = 1002;
       client2.send = function() {};
       Server.channels = { };
-      Server.channels[presence.name] = presence;
+      Server.channels[presence.to] = presence;
       done();
     });
   });
@@ -104,7 +104,7 @@ describe('given a presence resource',function() {
 
     it('expires within maxPersistence if set' , function(done) {
       Persistence.expire = function(scope, expiry) {
-        assert.equal(presence.name, scope);
+        assert.equal(presence.to, scope);
         assert.equal(expiry, 12 * 60 * 60);
         done();
       };
@@ -436,7 +436,7 @@ describe('given a presence resource',function() {
     it('userData should be stored on an incoming message', function() {
       var persistHash = Persistence.persistHash, called = false;
 
-      Persistence.persistHash = function(name, key, value) {
+      Persistence.persistHash = function(to, key, value) {
         called = true;
         assert.deepEqual(value.userData, { test: 1 });
       };

--- a/tests/radar_api.test.js
+++ b/tests/radar_api.test.js
@@ -41,9 +41,9 @@ exports['Radar api tests'] = {
 
   // GET /radar/status?accountName=test&scope=ticket/1
   'can get a status scope': function(done) {
-    var name = 'status:/test/ticket/1',
-        opts = Type.getByExpression(name),
-        status = new Status(name, {}, opts);
+    var to = 'status:/test/ticket/1',
+        opts = Type.getByExpression(to),
+        status = new Status(to, {}, opts);
 
     status.set({}, {
       key: 'foo',
@@ -93,9 +93,9 @@ exports['Radar api tests'] = {
 
     Type.register('message', message_type);
 
-    var name = 'message:/setStatus/chat/1',
-        opts = Type.getByExpression(name),
-        msgList = new MessageList(name, {}, opts);
+    var to = 'message:/setStatus/chat/1',
+        opts = Type.getByExpression(to),
+        msgList = new MessageList(to, {}, opts);
 
     msgList.publish({},{
       key: 'foo',

--- a/tests/rate_limiter.test.js
+++ b/tests/rate_limiter.test.js
@@ -3,8 +3,8 @@ var assert = require('assert'),
     limit = 1,
     clientId = '1', 
     clientId2 = '2', 
-    namePrefix = 'presence://thing/',
-    name = namePrefix + '1',
+    toPrefix = 'presence://thing/',
+    to = toPrefix + '1',
     rateLimiter;
 
 describe('rateLimiter', function() {
@@ -14,35 +14,35 @@ describe('rateLimiter', function() {
 
   it('add', function(){
     assert.equal(rateLimiter.count(clientId), 0);
-    rateLimiter.add(clientId, name);
+    rateLimiter.add(clientId, to);
     assert.equal(rateLimiter.count(clientId), 1);
   });
 
   it('remove', function(){
-    rateLimiter.add(clientId, name);
-    rateLimiter.remove(clientId, name);
+    rateLimiter.add(clientId, to);
+    rateLimiter.remove(clientId, to);
     assert.equal(rateLimiter.count(clientId), 0);
   });
 
   it('remove before adding', function(){
-    rateLimiter.remove(clientId, name);
+    rateLimiter.remove(clientId, to);
     assert.equal(rateLimiter.count(clientId), 0);
   });
 
   it('isAboveLimit', function(){
-    rateLimiter.add(clientId, name);
+    rateLimiter.add(clientId, to);
     assert(rateLimiter.isAboveLimit(clientId));
   });
 
   it ('duplicates should not count', function() {
-    rateLimiter.add(clientId, name);  
-    assert( ! rateLimiter.add(clientId, name) );
+    rateLimiter.add(clientId, to);  
+    assert( ! rateLimiter.add(clientId, to) );
     assert.equal(rateLimiter.count(clientId), 1);
   });
 
   it('removing by id', function() {
-    rateLimiter.add(clientId, name);
-    rateLimiter.add(clientId2, name);
+    rateLimiter.add(clientId, to);
+    rateLimiter.add(clientId2, to);
 
     assert.equal(rateLimiter.count(clientId), 1);
     assert.equal(rateLimiter.count(clientId2), 1);
@@ -53,14 +53,14 @@ describe('rateLimiter', function() {
     assert.equal(rateLimiter.count(clientId2), 1);
   });
 
-  it('removing by name', function() {
-    rateLimiter.add(clientId, name);
-    rateLimiter.add(clientId2, name);
+  it('removing by to', function() {
+    rateLimiter.add(clientId, to);
+    rateLimiter.add(clientId2, to);
 
     assert.equal(rateLimiter.count(clientId), 1);
     assert.equal(rateLimiter.count(clientId2), 1);
 
-    rateLimiter.removeByName(name);
+    rateLimiter.removeByTo(to);
 
     assert.equal(rateLimiter.count(clientId), 0);
     assert.equal(rateLimiter.count(clientId2), 0);

--- a/tests/server.unit.test.js
+++ b/tests/server.unit.test.js
@@ -18,7 +18,7 @@ describe('given a server',function() {
 
   it('should emit resource:new when allocating a new resource', function(done) {
     radarServer.on('resource:new', function(resource) {
-      assert.equal(resource.name, subscribeMessage.to);
+      assert.equal(resource.to, subscribeMessage.to);
       done();
     });
 


### PR DESCRIPTION
This is a refactor prior to using the radar_message library in radar server code.  The identifier *name* is used in many places where it signifies the *scope* or *to*, so I replaced *name* with *to* so that the meaning is clear.  Besides this, *name* is used as a property name in other objects also, which can be confusing, as well as generic.  **Data attribute** names associated with resource *name* have not been changed.

**NB** in the radar api code, the identifier *scope* is already being used, so I could not use *scope* as a replacement for *name* in resources.  Curiously, in the api code, *scope* does not mean the full scope, but the suffix of what we know as the scope.  (*to*, on the other hand, contains the full scope value.)

**Note** - on the initial commit, 168 additions, 168 removals, so this should be a clean 1-for-1 replacement.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-573

### Risks
 - None