### PR TITLE
Changes to fix storeData bug in client.js

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -152,8 +152,23 @@ Client.prototype._storeDataPresences = function (messageIn, presCount) {
 Client.prototype.loadData = function (callback) {
   var self = this;
 
-  self._loadDataSubscriptions(function () {
-    self._loadDataPresences(callback);
+  self.readData(function (result) {
+    self.presences = result.presences;
+    self.subscriptions = result.subscriptions;
+  });
+};
+
+Client.prototype.readData = function (callback) {
+  var self = this,
+      result = {};
+
+  self._readDataSubscriptions(function (subscriptions) {
+    self._readDataPresences(function(presences){
+      callback({
+        presences: presences,
+        subscriptions: subscriptions
+      });
+    });
   });
 };
 
@@ -170,31 +185,24 @@ Client.prototype._keyGet = function (accountName) {
   return key;
 };
 
-Client.prototype._loadDataSubscriptions = function (callback) {
-  var subscriptionHashname = this.key + '_subs',
-      self = this;
+
+Client.prototype._readDataSubscriptions = function (callback) {
+  var self = this,
+      subscriptionHashname = this.key + '_subs';
 
   // Get persisted subscriptions
   Core.Persistence.readHashAll(subscriptionHashname, function (replies) {
-    self.subscriptions = replies || {};
-
-    if (callback) {
-      callback();
-    }
+    callback(replies || {});
   });
 };
 
-Client.prototype._loadDataPresences = function (callback) {
-  var presenceHashname = this.key + '_pres',
-      self = this;
+Client.prototype._readDataPresences = function (callback) {
+  var self = this,
+      presenceHashname = this.key + '_pres';
 
   // Get persisted presences
   Core.Persistence.readHashAll(presenceHashname, function (replies) {
-    self.presences = replies || {};
-
-    if (callback) {
-      callback();
-    }
+    callback(replies || {});
   });
 };
 

--- a/client/client.js
+++ b/client/client.js
@@ -14,8 +14,10 @@ function Client (name, id, accountName, version) {
 }
 
 // 86400:  number of seconds in 1 day
-var DEFAULT_DATA_TTL = 86400;
-var LOG_WINDOW_SIZE = 10;
+var DEFAULT_DATA_TTL = 86400,
+    LOG_WINDOW_SIZE = 10,
+    SUBSCRIPTION_SUFFIX = '/subscriptions',
+    PRESENCE_SUFFIX = '/presences';
 
 // Class properties
 Client.clients = {};                  // keyed by name
@@ -97,7 +99,7 @@ Client.prototype.storeData = function (messageIn) {
 Client.prototype._storeDataSubscriptions = function (messageIn) {
   var message = _cloneForStorage(messageIn),
       to = message.to,
-      subscriptionHashname = this.key + '_subs',
+      subscriptionHashname = this.key + SUBSCRIPTION_SUFFIX,
       isSubscribed;
 
   // Persist the message data, according to type
@@ -130,7 +132,7 @@ Client.prototype._storeDataSubscriptions = function (messageIn) {
 Client.prototype._storeDataPresences = function (messageIn) {
   var message = _cloneForStorage(messageIn),
       to = message.to,
-      presenceHashname = this.key + '_pres',
+      presenceHashname = this.key + PRESENCE_SUFFIX,
       isOnline;
 
   // Persist the message data, according to type
@@ -195,7 +197,7 @@ Client.prototype._keyGet = function (accountName) {
 
 Client.prototype._readDataSubscriptions = function (callback) {
   var self = this,
-      subscriptionHashname = this.key + '_subs';
+      subscriptionHashname = this.key + SUBSCRIPTION_SUFFIX;
 
   // Get persisted subscriptions
   Core.Persistence.readHashAll(subscriptionHashname, function (replies) {
@@ -205,7 +207,7 @@ Client.prototype._readDataSubscriptions = function (callback) {
 
 Client.prototype._readDataPresences = function (callback) {
   var self = this,
-      presenceHashname = this.key + '_pres';
+      presenceHashname = this.key + PRESENCE_SUFFIX;
 
   // Get persisted presences
   Core.Persistence.readHashAll(presenceHashname, function (replies) {

--- a/client/client.js
+++ b/client/client.js
@@ -139,24 +139,20 @@ Client.prototype._storeDataPresences = function (messageIn) {
       existingPresence;
 
   // Persist the message data, according to type
-  switch(message.op) {
-    case 'set':
-      if (to.substr(0, 'presence:/'.length) == 'presence:/') {
-        existingPresence = this.presences[to];
+  if (message.op === 'set' && to.substr(0, 'presence:/'.length) == 'presence:/') {
+    existingPresence = this.presences[to];
 
-        // Should go offline
-        if (existingPresence && messageIn.value === 'offline') {
-          delete this.presences[to];
-          Core.Persistence.deleteHash(presencesKey, to);
-          return true;
-        } else if (!existingPresence && message.value !== 'offline') {
-          this.presences[to] = message;
-          Core.Persistence.expire(presencesKey, Client.getDataTTL());
-          Core.Persistence.persistHash(presencesKey, to, message);
-          return true;
-        }
-      }
-      break;
+    // Should go offline
+    if (existingPresence && messageIn.value === 'offline') {
+      delete this.presences[to];
+      Core.Persistence.deleteHash(presencesKey, to);
+      return true;
+    } else if (!existingPresence && message.value !== 'offline') {
+      this.presences[to] = message;
+      Core.Persistence.expire(presencesKey, Client.getDataTTL());
+      Core.Persistence.persistHash(presencesKey, to, message);
+      return true;
+    }
   }
 
   return false;

--- a/client/client.js
+++ b/client/client.js
@@ -66,9 +66,7 @@ Client.create = function (message) {
 
 // Persist subscriptions and presences when not already persisted in memory
 Client.prototype.storeData = function (messageIn) {
-  var subCount = Object.keys(this.subscriptions).length,
-      presCount = Object.keys(this.presences).length,
-      processedOp = false;
+  var processedOp = false;
 
   // Persist the message data, according to type
   switch(messageIn.op) {
@@ -86,14 +84,21 @@ Client.prototype.storeData = function (messageIn) {
   // FIXME: For now log everything Later, enable sample logging. 
   // if (processedOp && subCount % LOG_WINDOW_SIZE === 0) {
   if (processedOp) {
-    log.info('#storeData', { 
-      client_id: this.id,
-      subscription_count: subCount,
-      presence_count: presCount
-    });
+    this._logState();
   }
 
   return true;
+};
+
+Client.prototype._logState = function() {
+  var subCount = Object.keys(this.subscriptions).length,
+      presCount = Object.keys(this.presences).length;
+
+  log.info('#storeData', { 
+    client_id: this.id,
+    subscription_count: subCount,
+    presence_count: presCount
+  });
 };
 
 Client.prototype._storeDataSubscriptions = function (messageIn) {

--- a/client/client.js
+++ b/client/client.js
@@ -15,6 +15,7 @@ function Client (name, id, accountName, version) {
 
 // 86400:  number of seconds in 1 day
 var DEFAULT_DATA_TTL = 86400;
+var LOG_WINDOW_SIZE = 10;
 
 // Class properties
 Client.clients = {};                  // keyed by name
@@ -103,7 +104,7 @@ Client.prototype._storeDataSubscriptions = function (messageIn, subCount) {
         delete this.subscriptions[to];
         Core.Persistence.expire(subscriptionHashname, Client.getDataTTL());
         Core.Persistence.deleteHash(subscriptionHashname, to);
-        logNow = 0 === subCount % 10;
+        logNow = 0 === subCount % LOG_WINDOW_SIZE;
       }
       break;
 
@@ -115,7 +116,7 @@ Client.prototype._storeDataSubscriptions = function (messageIn, subCount) {
         this.subscriptions[to] = message;
         Core.Persistence.expire(subscriptionHashname, Client.getDataTTL());
         Core.Persistence.persistHash(subscriptionHashname, to, message);
-        logNow = 0 === subCount % 10;
+        logNow = 0 === subCount % LOG_WINDOW_SIZE;
       }
       break;
   }
@@ -139,7 +140,7 @@ Client.prototype._storeDataPresences = function (messageIn, presCount) {
           this.presences[to] = message;
           Core.Persistence.expire(presenceHashname, Client.getDataTTL());
           Core.Persistence.persistHash(presenceHashname, to, message);
-          logNow = 0 === presCount % 10;
+          logNow = 0 === presCount % LOG_WINDOW_SIZE;
         }
       }
       break;

--- a/client/client.js
+++ b/client/client.js
@@ -116,9 +116,7 @@ Client.prototype._storeDataSubscriptions = function (messageIn) {
     case 'sync':
     case 'subscribe':
       existingSubscription = this.subscriptions[to];
-      if (!existingSubscription ||
-            (existingSubscription.op != 'sync' && !_.isEqual(existingSubscription, message))) {
-
+      if (!existingSubscription || (existingSubscription.op !== 'sync' && message.op === 'sync')) {
         this.subscriptions[to] = message;
         Core.Persistence.expire(subscriptionsKey, Client.getDataTTL());
         Core.Persistence.persistHash(subscriptionsKey, to, message);
@@ -141,11 +139,12 @@ Client.prototype._storeDataPresences = function (messageIn) {
       if (to.substr(0, 'presence:/'.length) == 'presence:/') {
         existingPresence = this.presences[to];
 
-        if (messageIn.value === 'offline' && existingPresence) {
+        // Should go offline
+        if (existingPresence && messageIn.value === 'offline') {
           delete this.presences[to];
           Core.Persistence.deleteHash(presencesKey, to);
           return true;
-        } else if (!existingPresence || (!_.isEqual(existingPresence, message))) {
+        } else if (!existingPresence && message.value !== 'offline') {
           this.presences[to] = message;
           Core.Persistence.expire(presencesKey, Client.getDataTTL());
           Core.Persistence.persistHash(presencesKey, to, message);

--- a/client/client.js
+++ b/client/client.js
@@ -103,7 +103,7 @@ Client.prototype._storeDataSubscriptions = function (messageIn, subCount) {
         delete this.subscriptions[to];
         Core.Persistence.expire(subscriptionHashname, Client.getDataTTL());
         Core.Persistence.deleteHash(subscriptionHashname, to);
-        logNow = 0 === subCount % 2;
+        logNow = 0 === subCount % 10;
       }
       break;
 
@@ -115,7 +115,7 @@ Client.prototype._storeDataSubscriptions = function (messageIn, subCount) {
         this.subscriptions[to] = message;
         Core.Persistence.expire(subscriptionHashname, Client.getDataTTL());
         Core.Persistence.persistHash(subscriptionHashname, to, message);
-        logNow = 0 === subCount % 2;
+        logNow = 0 === subCount % 10;
       }
       break;
   }

--- a/server/server.js
+++ b/server/server.js
@@ -247,7 +247,6 @@ Server.prototype._handleResourceMessage = function(socket, message, messageType)
       (this.subs[to] ? 'is subscribed' : 'not subscribed')
     );
 
-    // TODO: Reimplement in a less agressive way. 
     this._persistClientData(socket, message);
     this._storeResource(resource);
     this._persistenceSubscribe(resource.to, socket.id);

--- a/server/server.js
+++ b/server/server.js
@@ -248,7 +248,7 @@ Server.prototype._handleResourceMessage = function(socket, message, messageType)
     );
 
     // TODO: Reimplement in a less agressive way. 
-    // this._persistClientData(socket, message);
+    this._persistClientData(socket, message);
     this._storeResource(resource);
     this._persistenceSubscribe(resource.to, socket.id);
     this._updateLimits(socket, message, resource.options);
@@ -262,9 +262,7 @@ Server.prototype._handleResourceMessage = function(socket, message, messageType)
 Server.prototype._replayMessagesFromClient = function (socket, client) {
   var subscriptions = client.subscriptions,
       presences = client.presences,
-      message,
-      messageType,
-      key;
+      message, messageType, key;
 
   // Pause events on the inbound socket
   Pauseable.pause(socket);
@@ -405,19 +403,26 @@ Server.prototype._sendErrorMessage = function(socket, value, origin) {
 
 // Initialize the current client
 Server.prototype._initClient = function (socket, message) {
-  Client.create(message);
+  var client = Client.create(message);
+
+  // TODO - example of loadData use - disabled for now
+  //client.loadData(this._replayMessagesFromClient.bind(this, socket, client));
 };
 
-Server.prototype._stampMessage = function(socket, message) {
+Server.prototype._stampMessage = function (socket, message) {
   return Stamper.stamp(message, socket.id);
 };
 
-function _parseJSON(data) {
+// Private functions
+// TODO: move to util module
+function _parseJSON (data) {
+  var message = false;
+
   try {
-    var message = JSON.parse(data);
-    return message;
+    message = JSON.parse(data);
   } catch(e) { }
-  return false;
+
+  return message;
 }
 
 module.exports = Server;

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -1,0 +1,88 @@
+var common = require('./common.js'),
+    assert = require('assert'),
+    Client = require('../client/client.js'),
+    Persistence = require('../core').Persistence,
+    client, subscriptions;
+
+describe('Client', function() {
+  beforeEach(function(done) {
+    common.startPersistence(done); // clean up
+    client = new Client('joe', 1, 'test', 1);
+    subscriptions = {};
+    presences = {};
+  });
+
+  describe('.storeData and .loadData', function() {
+    describe('subscriptions', function() {
+      it('should store subscribe operations', function(done) {
+        var to = 'presence:/test/account/ticket/1',
+            message = { to: to, op: 'subscribe' };
+        
+        subscriptions[to] = message;
+
+        client.storeData(message);
+
+        client.readData(function(state) {
+          assert.deepEqual(state, {
+            subscriptions: subscriptions,
+            presences: {}
+          });
+          done();
+        });
+      });
+
+      it('should store sync as subscribes', function(done) {
+        var to = 'presence:/test/account/ticket/1',
+            message = { to: to, op: 'sync' };
+        
+        subscriptions[to] = message;
+
+        client.storeData(message);
+
+        client.readData(function(state) {
+          assert.deepEqual(state, {
+            subscriptions: subscriptions,
+            presences: {}
+          });
+          done();
+        });
+      });
+
+      it('should remove subscriptions on unsubscribe', function(done) {
+        var to = 'presence:/test/account/ticket/1',
+            subscribe = { to: to, op: 'subscribe' },
+            unsubscribe = { to: to, op: 'unsubscribe' };
+        
+        client.storeData(subscribe);
+        client.storeData(unsubscribe);
+
+        client.readData(function(state) {
+          assert.deepEqual(state, {
+            subscriptions: {},
+            presences: {}
+          });
+          done();
+        });
+      });
+    });
+
+    describe('presences', function() {
+      it('should store set operations', function(done) {
+        var to = 'presence:/test/account/ticket/1',
+            message = { to: to, op: 'set' };
+        
+        presences[to] = message;
+
+        client.storeData(message);
+
+        client.readData(function(state) {
+          assert.deepEqual(state, {
+            subscriptions: {},
+            presences: presences
+          });
+          done();
+        });
+      });
+    });
+  });
+});

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -64,6 +64,44 @@ describe('Client', function() {
           done();
         });
       });
+
+      it('sync after subscribe, keeps the sync', function(done) {
+        var to = 'presence:/test/account/ticket/1',
+            subscribe = { to: to, op: 'subscribe' },
+            sync = { to: to, op: 'sync' };
+        
+        client.storeData(subscribe);
+        client.storeData(sync);
+
+        subscriptions[to] = sync;
+
+        client.readData(function(state) {
+          assert.deepEqual(state, {
+            subscriptions: subscriptions,
+            presences: {}
+          });
+          done();
+        });
+      });
+
+      it('subscribe after sync, keeps the sync', function(done) {
+        var to = 'presence:/test/account/ticket/1',
+            subscribe = { to: to, op: 'subscribe' },
+            sync = { to: to, op: 'sync' };
+        
+        client.storeData(sync);
+        client.storeData(subscribe);
+
+        subscriptions[to] = sync;
+
+        client.readData(function(state) {
+          assert.deepEqual(state, {
+            subscriptions: subscriptions,
+            presences: {}
+          });
+          done();
+        });
+      });
     });
 
     describe('presences', function() {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -67,18 +67,36 @@ describe('Client', function() {
     });
 
     describe('presences', function() {
-      it('should store set operations', function(done) {
+      it('should store set online operations', function(done) {
         var to = 'presence:/test/account/ticket/1',
-            message = { to: to, op: 'set' };
+            message = { to: to, op: 'set', value: 'online' };
         
-        presences[to] = message;
-
         client.storeData(message);
+
+        delete message.value;
+        presences[to] = message;
 
         client.readData(function(state) {
           assert.deepEqual(state, {
             subscriptions: {},
             presences: presences
+          });
+          done();
+        });
+      });
+
+      it('should remove presence when set offline', function(done) {
+        var to = 'presence:/test/account/ticket/1',
+            online = { to: to, op: 'set', value: 'online' },
+            offline = { to: to, op: 'set', value: 'offline' };
+        
+        client.storeData(online);
+        client.storeData(offline);
+
+        client.readData(function(state) {
+          assert.deepEqual(state, {
+            subscriptions: {},
+            presences: {}
           });
           done();
         });

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -7,7 +7,7 @@ var common = require('./common.js'),
 describe('Client', function() {
   beforeEach(function(done) {
     common.startPersistence(done); // clean up
-    client = new Client('joe', 1, 'test', 1);
+    client = new Client('joe', Math.random(), 'test', 1);
     subscriptions = {};
     presences = {};
   });


### PR DESCRIPTION
client.storeData was too bulky in terms of what it used to store in persistence, so I modified it to store only the "to" and "op" data for *subscriptions* and *presences*.  In addition, the old code stored an entire client instance each time a *subscription* or *presence* was modified; now it stores only a separate hash key/value pair for the relevant *subscription* or *presence* that is changed.  Logging has also been reduced by logging counts on every 10th change (we could make the logging window configurable, but I believe such complexity is not worth it.)

In persistence, two hashes are now created for each unique clientId, whereas before the whole server-side client was stored on a single key.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-564

### Risks
 - Low: Testing needs to be done locally to verify that redis data sizes are as expected