### PR TITLE
Add engines property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Realtime apps with a high level API based on engine.io",
   "version": "0.16.5",
   "author": "Mikito Takada <mikito.takada@gmail.com>",
+  "engines" : {
+    "node": "0.10 - 4"
+  },
   "contributors": [
     {
       "name": "Sam Shull",


### PR DESCRIPTION
Explicitly declare the node versions that we support, 0.10.x through 4.x

Relevant documentation for this feature:
- [`engines` property in package.json](https://docs.npmjs.com/files/package.json#engines)
- [semver ranges](https://docs.npmjs.com/misc/semver#hyphen-ranges-x-y-z-a-b-c)

## Needed to merge
- :+1: from team

## Risks
- None