### PR TITLE
Feature suggestion: Filters support

### DIFF
--- a/core/middleware.js
+++ b/core/middleware.js
@@ -1,0 +1,40 @@
+var async = require('async');
+
+var Middleware = {
+  use: function(middleware) {
+    this._middleware = this._middleware || [];
+    this._middleware.push(middleware);
+  },
+
+  runMiddleware: function() {
+    var context = arguments[0],
+        args = [].slice.call(arguments, 1, -1),
+        callback = [].slice.call(arguments, -1)[0];
+
+    if (!this._middleware) {
+      callback();
+      return;
+    }
+
+    var process = function (middleware, next) {
+      if (middleware[context]) {
+        middleware[context].apply(middleware, args.concat(next));
+      } else {
+        next();
+      }
+    };
+
+    async.each(this._middleware, process, callback);
+  }
+};
+
+module.exports = {
+  mixin: function(receiver) {
+    var o = Middleware, k;
+    for (k in o) {
+      if (o.hasOwnProperty(k)) {
+        receiver.prototype[k] = o[k];
+      }
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/zendesk/radar.git"
   },
   "dependencies": {
+    "async": "*", 
     "callback_tracker": "*",
     "engine.io": "1.4.2",
     "miniee": "*",

--- a/server/server.js
+++ b/server/server.js
@@ -226,7 +226,7 @@ Server.prototype._processMessage = function(socket, message) {
     return;
   }
 
-  this.runMiddleware('pre', socket, message, messageType, function lastly (err) {
+  this.runMiddleware('onMessage', socket, message, messageType, function lastly (err) {
     if (err) {
       logging.warn('#socket.message - pre filter halted execution', message);
       return;
@@ -265,7 +265,8 @@ Server.prototype._handleResourceMessage = function(socket, message, messageType)
       (this.subs[to] ? 'is subscribed' : 'not subscribed')
     );
 
-    this.runMiddleware('post', socket, message, messageType, function (err) {
+
+    this.runMiddleware('onResource', socket, resource, message, messageType, function (err) {
       if (err) {
         logging.warn('#socket.message - post filter halted execution', message);
       } else {

--- a/server/server.js
+++ b/server/server.js
@@ -34,12 +34,12 @@ Server.prototype.attach = function(httpServer, configuration) {
 
 // Destroy empty resource
 Server.prototype.destroyResource = function(to) {
-  var messageType = this._getMessageType(to);
+  var messageType = this._getMessageType(to),
+      resource = this.resources[to];
 
-  if (this.resources[to]) {
-    resource = this.resources[to];
+  if (resource) {
     this.emit('resource:destroy', resource);
-    this.resources[to].destroy();
+    resource.destroy();
   }
 
   if (this._rateLimiters[messageType.name]) {

--- a/server/server.js
+++ b/server/server.js
@@ -229,7 +229,10 @@ Server.prototype._processMessage = function(socket, message) {
   this.runMiddleware('pre', socket, message, messageType, function lastly (err) {
     if (err) {
       logging.warn('#socket.message - pre filter halted execution', message);
-    } else if (message.op === 'nameSync') {
+      return;
+    }
+    
+    if (message.op === 'nameSync') {
       logging.info('#socket.message - nameSync', message, socket.id);
       self._initClient(socket, message);
       socket.send({ op: 'ack', value: message && message.ack });

--- a/tests/common.js
+++ b/tests/common.js
@@ -126,7 +126,7 @@ module.exports = {
     radarServer.attach(httpServer, configuration);
 
     if (done) {
-      setTimeout(done, 100);
+      setTimeout(done, 200);
     }
     
     return radarServer;

--- a/tests/presence.unit.test.js
+++ b/tests/presence.unit.test.js
@@ -472,6 +472,10 @@ describe('a presence resource', function() {
       radarServer = Common.createRadarServer(done);
     });
 
+    afterEach(function(done) {
+      radarServer.terminate(done)
+    });
+
     it('should emit incomming messages', function(done) {
       var subscribeMessage = { op: 'subscribe', to: 'presence:/z1/test/ticket/1' };
 

--- a/tests/server.filters.unit.test.js
+++ b/tests/server.filters.unit.test.js
@@ -46,13 +46,13 @@ describe('given a server with filters', function() {
         done();
       };
 
-      radarServer.filter({
-        pre: function(client, message, options) {
+      radarServer.use({
+        pre: function(client, message, options, next) {
           called = true;
           assert.equal(client.id, socket.id);
           assert.equal(options.type, 'Control');
           assert.deepEqual(message, controlMessage);
-          return true;
+          next();
         }
       });
       
@@ -68,12 +68,12 @@ describe('given a server with filters', function() {
         done();
       };
 
-      radarServer.filter({
-        pre: function(client, message, options) {
+      radarServer.use({
+        pre: function(client, message, options, next) {
           called = true;
           assert.equal(options.type, 'Control');
           socket.send({ op: 'err' });
-          return false;
+          next('err');
         }
       });
       
@@ -95,21 +95,21 @@ describe('given a server with filters', function() {
       };
 
       var firstFilter = {
-        pre: function(client, message, options) {
+        pre: function(client, message, options, next) {
           client.send(1);
-          return true;
+          next();
         }
       };
 
       var secondFilter = {
-        pre: function(client, message, options) {
+        pre: function(client, message, options, next) {
           client.send(2);
-          return true;
+          next();
         }
       };
       
-      radarServer.filter(firstFilter);
-      radarServer.filter(secondFilter);
+      radarServer.use(firstFilter);
+      radarServer.use(secondFilter);
 
       radarServer._processMessage(socket, controlMessage);  
     });

--- a/tests/server.filters.unit.test.js
+++ b/tests/server.filters.unit.test.js
@@ -1,0 +1,117 @@
+var common = require('./common.js'),
+    assert = require('assert'),
+    RadarTypes = require('../core/lib/type.js'),
+    controlMessage = { 
+      to: 'control:/dev/test',
+      op: 'nameSync',
+      options: {
+        association: {
+          id: 1,
+          name: 1
+        }
+      }
+    },
+    radarServer,
+    socket;
+
+describe('given a server with filters', function() {
+  beforeEach(function(done) {
+    radarServer = common.createRadarServer(done);
+    socket = { id: 1 };
+  });
+
+  afterEach(function(done) {
+    radarServer.terminate(done);
+  });
+
+  describe('with no filters', function() {
+    it('should not halt execution', function(done) {
+      socket.send = function(message) {
+        assert.equal('ack', message.op);
+        done();
+      };
+
+      radarServer._processMessage(socket, controlMessage);
+    });
+  });
+
+  describe('with 1 filter', function() {
+    it('if OK, it should run it and continue', function(done) {
+      var called = false;
+
+      // Will be called
+      socket.send = function(message) {
+        assert.equal('ack', message.op);
+        assert.ok(called);
+        done();
+      };
+
+      radarServer.filter({
+        pre: function(client, message, options) {
+          called = true;
+          assert.equal(client.id, socket.id);
+          assert.equal(options.type, 'Control');
+          assert.deepEqual(message, controlMessage);
+          return true;
+        }
+      });
+      
+      radarServer._processMessage(socket, controlMessage);  
+    });
+
+    it('if NOT OK, it should run it and halt', function(done) {
+      var called = false;
+
+      socket.send = function(message) {
+        assert.equal('err', message.op);
+        assert(called);
+        done();
+      };
+
+      radarServer.filter({
+        pre: function(client, message, options) {
+          called = true;
+          assert.equal(options.type, 'Control');
+          socket.send({ op: 'err' });
+          return false;
+        }
+      });
+      
+      radarServer._processMessage(socket, controlMessage);  
+    });
+  });
+
+  describe('with multiple filters', function() {
+    it('should respect order', function(done) {
+      var previous;
+
+      socket.send = function(value) {
+        if (value === 1) {
+          previous = value;
+        } else if (value === 2) {
+          assert.equal(previous, 1);
+          done();
+        }
+      };
+
+      var firstFilter = {
+        pre: function(client, message, options) {
+          client.send(1);
+          return true;
+        }
+      };
+
+      var secondFilter = {
+        pre: function(client, message, options) {
+          client.send(2);
+          return true;
+        }
+      };
+      
+      radarServer.filter(firstFilter);
+      radarServer.filter(secondFilter);
+
+      radarServer._processMessage(socket, controlMessage);  
+    });
+  });
+});  

--- a/tests/server.middleware.unit.test.js
+++ b/tests/server.middleware.unit.test.js
@@ -47,7 +47,7 @@ describe('given a server with filters', function() {
       };
 
       radarServer.use({
-        pre: function(client, message, options, next) {
+        onMessage: function(client, message, options, next) {
           called = true;
           assert.equal(client.id, socket.id);
           assert.equal(options.type, 'Control');
@@ -69,7 +69,7 @@ describe('given a server with filters', function() {
       };
 
       radarServer.use({
-        pre: function(client, message, options, next) {
+        onMessage: function(client, message, options, next) {
           called = true;
           assert.equal(options.type, 'Control');
           socket.send({ op: 'err' });
@@ -83,26 +83,26 @@ describe('given a server with filters', function() {
 
   describe('with multiple filters', function() {
     it('should respect order', function(done) {
-      var previous;
+      var onMessagevious;
 
       socket.send = function(value) {
         if (value === 1) {
-          previous = value;
+          onMessagevious = value;
         } else if (value === 2) {
-          assert.equal(previous, 1);
+          assert.equal(onMessagevious, 1);
           done();
         }
       };
 
       var firstFilter = {
-        pre: function(client, message, options, next) {
+        onMessage: function(client, message, options, next) {
           client.send(1);
           next();
         }
       };
 
       var secondFilter = {
-        pre: function(client, message, options, next) {
+        onMessage: function(client, message, options, next) {
           client.send(2);
           next();
         }

--- a/tests/server.unit.test.js
+++ b/tests/server.unit.test.js
@@ -16,6 +16,10 @@ describe('given a server',function() {
     };
   });
 
+  afterEach(function(done) {
+    radarServer.terminate(done);
+  });
+
   it('should emit resource:new when allocating a new resource', function(done) {
     radarServer.on('resource:new', function(resource) {
       assert.equal(resource.to, subscribeMessage.to);

--- a/tests/stamper.test.js
+++ b/tests/stamper.test.js
@@ -1,4 +1,3 @@
-
 var assert = require('assert'),
     Stamper = require('../core/stamper.js'),
     sentryName = 'theSentryName',

--- a/tests/status.unit.test.js
+++ b/tests/status.unit.test.js
@@ -179,6 +179,10 @@ describe('a status resource', function() {
       radarServer = Common.createRadarServer(done);
     });
 
+    afterEach(function(done) {
+      radarServer.terminate(done);
+    });
+
     it('should emit incomming messages', function(done) {
       var subscribeMessage = { op: 'subscribe', to: 'status:/z1/test/ticket/1' };
 


### PR DESCRIPTION
(UPDATED) 

So, based on our need to change radar OSS all the time in order to accommodate some of our needs, I'm suggesting adding support for filters, and later implement authentication, quota, limiting or whatever as a filter. 

Consider the following example:

    var AuthManager = function() { };

    AuthManager.prototype.onMessage = function(client, message, options, next) {
        next();
    }

    AuthManager.prototype.onResource = function(client, resource, message, options, next) {
        next();
    }

    var Radar = require('radar').server;
    radarServer = new Radar();
    radarServer.use(new AuthManager);

This interface allows multiple filters, where the order will be respected. 

    radarServer.use(new AuthManager);
    radarServer.use(new QuotaManager);

### Steps to merge
 - [ ] :+1: of the @zendesk/zendesk-radar team

### Risks
 - None
