### PR TITLE
Upgrade persistence@1.0.5 and pin depdendencies in package.json

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
-### Current master
+### 0.16.8
+* Pin dependencies in package.json
+* Upgrade to persistence@1.0.5
 
 ### 0.16.7
 * Add ability to log abuse on subscriptions without preventing it. 

--- a/package.json
+++ b/package.json
@@ -30,22 +30,21 @@
     "url": "https://github.com/zendesk/radar.git"
   },
   "dependencies": {
-    "async": "*",
-    "callback_tracker": "*",
+    "async": "^1.5.0",
+    "callback_tracker": "0.1.0",
     "engine.io": "1.4.2",
-    "miniee": "*",
-    "minilog": "*",
-    "nomnom": "*",
-    "pauseable": "*",
-    "persistence": ">= 1.0.3",
-    "semver": "*",
-    "underscore": "*",
+    "miniee": "0.0.5",
+    "minilog": "2.0.8",
+    "nomnom": "^1.8.1",
+    "persistence": ">= 1.0.5",
+    "semver": "^5.0.3",
+    "underscore": "^1.8.3",
     "uuid": "^2.0.1"
   },
   "devDependencies": {
-    "mocha": "*",
-    "radar_client": "*",
-    "simple_sentinel": "*"
+    "mocha": "^2.3.3",
+    "radar_client": "^0.14.6",
+    "simple_sentinel": "^0.1.8"
   },
   "scripts": {
     "prestart": "npm run check-modules",

--- a/server/server.js
+++ b/server/server.js
@@ -7,7 +7,6 @@ var _ = require('underscore'),
     DefaultEngineIO = require('engine.io'),
     Semver = require('semver'),
     Client = require('../client/client.js'),
-    Pauseable = require('pauseable'),
     Middleware = require('../core/middleware.js'),
     RateLimiter = require('../core/rate_limiter.js'),
     Stamper = require('../core/stamper.js');


### PR DESCRIPTION
Also removes unused dependency `pauseable` which is was not used in this repo
(usage removed in https://github.com/zendesk/radar/commit/a2f56dfa10ac7308647c3e5c0bf522bceaf4fe61#diff-ea75b530d74f94670cea053feb8b961b )

Required
========
- [ ] :+1: from team

Risks
=======
- None