### PR TITLE
Reformat source to npm.im/standard format

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1,11 +1,11 @@
-var hostname = require('os').hostname(),
-  Router = require('./lib/router.js'),
-  RadarApi = require('./apis/radar.js')
+var hostname = require('os').hostname()
+var Router = require('./lib/router.js')
+var RadarApi = require('./apis/radar.js')
 
 var api = new Router()
 
 function homepage (req, res) {
-  res.setHeader('Content-Type', 'text/plain'); // IE will otherwise try to save the response instead of just showing it.
+  res.setHeader('Content-Type', 'text/plain') // IE will otherwise try to save the response instead of just showing it
   res.end(JSON.stringify({ pong: 'Radar running at ' + hostname }))
 }
 
@@ -16,10 +16,10 @@ api.get(/^\/engine.io\/ping.*$/, homepage)
 
 // Radar API
 
-api.post(new RegExp('^/radar/status'), RadarApi.setStatus)
-api.get(new RegExp('^/radar/status'), RadarApi.getStatus)
-api.post(new RegExp('^/radar/message'), RadarApi.setMessage)
-api.get(new RegExp('^/radar/message'), RadarApi.getMessage)
-api.get(new RegExp('^/radar/presence(.*)'), RadarApi.getPresence)
+api.post(/^\/radar\/status/, RadarApi.setStatus)
+api.get(/^\/radar\/status/, RadarApi.getStatus)
+api.post(/^\/radar\/message/, RadarApi.setMessage)
+api.get(/^\/radar\/message/, RadarApi.getMessage)
+api.get(/^\/radar\/presence(.*)/, RadarApi.getPresence)
 
 module.exports = api

--- a/api/apis/radar.js
+++ b/api/apis/radar.js
@@ -1,10 +1,10 @@
-var url = require('url'),
-  Status = require('../../core').Status,
-  MessageList = require('../../core').MessageList,
-  Presence = require('../../core').Presence,
-  PresenceManager = require('../../core').PresenceManager,
-  Type = require('../../core').Type,
-  hostname = require('os').hostname()
+var url = require('url')
+var Status = require('../../core').Status
+var MessageList = require('../../core').MessageList
+var Presence = require('../../core').Presence
+var PresenceManager = require('../../core').PresenceManager
+var Type = require('../../core').Type
+var hostname = require('os').hostname()
 
 function jsonResponse (response, object) {
   response.setHeader('Content-type', 'application/json')
@@ -15,10 +15,10 @@ function jsonResponse (response, object) {
 function parseData (response, data, ResourceType) {
   var parameters = data
 
-  if (typeof data == 'string') {
+  if (typeof data === 'string') {
     try {
       parameters = JSON.parse(data)
-    } catch(e) {
+    } catch (e) {
       parameters = false
     }
   }
@@ -27,9 +27,9 @@ function parseData (response, data, ResourceType) {
     return jsonResponse(response, {})
   }
 
-  var resourceTo = ResourceType.prototype.type + ':/' + parameters.accountName + '/' + parameters.scope,
-    options = Type.getByExpression(resourceTo),
-    resource = new ResourceType(resourceTo, {}, options)
+  var resourceTo = ResourceType.prototype.type + ':/' + parameters.accountName + '/' + parameters.scope
+  var options = Type.getByExpression(resourceTo)
+  var resource = new ResourceType(resourceTo, {}, options)
 
   resource.accountName = parameters.accountName
   resource.scope = parameters.scope
@@ -56,7 +56,7 @@ function setStatus (req, res, re, data) {
         op: 'set',
         to: status.to,
         key: status.key,
-        value: status.value,
+        value: status.value
       }, status.options.policy || {}, function () {
         jsonResponse(res, {})
       })
@@ -65,8 +65,8 @@ function setStatus (req, res, re, data) {
 
 // curl -k "https://localhost/radar/status?accountName=test&scope=ticket/1"
 function getStatus (req, res) {
-  var parts = url.parse(req.url, true),
-    status = parseData(res, parts.query, Status)
+  var parts = url.parse(req.url, true)
+  var status = parseData(res, parts.query, Status)
 
   if (status) {
     status._get('status:/' + status.accountName + '/' + status.scope, function (replies) {
@@ -95,8 +95,8 @@ function setMessage (req, res, re, data) {
 }
 
 function getMessage (req, res) {
-  var parts = url.parse(req.url, true),
-    message = parseData(res, parts.query, MessageList)
+  var parts = url.parse(req.url, true)
+  var message = parseData(res, parts.query, MessageList)
 
   if (message) {
     message._sync(message.to, message.options.policy || {}, function (replies) {
@@ -114,11 +114,11 @@ function getMessage (req, res) {
 //  - Response for single scope: { userId: { "clients": { clientId1: {}, clientId2: {} }, userType: }  }
 //  - Response for multiple scopes: {  scope1: ... above ..., scope2: ... above ...  }
 function getPresence (req, res) {
-  var parts = url.parse(req.url, true),
-    q = parts.query
-  if (!q || !q.accountName) { return res.end(); }
-  if (!(q.scope || q.scopes)) { return res.end(); }
-  var versionNumber = parseInt(q.version)
+  var parts = url.parse(req.url, true)
+  var q = parts.query
+  if (!q || !q.accountName) { return res.end() }
+  if (!(q.scope || q.scopes)) { return res.end() }
+  var versionNumber = parseInt(q.version, 10)
   // Sadly, the responses are different when dealing with multiple scopes so can't just put these in a control flow
   if (q.scope) {
     var monitor = new PresenceManager('presence:/' + q.accountName + '/' + q.scope, {}, Presence.sentry)
@@ -126,9 +126,6 @@ function getPresence (req, res) {
       res.setHeader('Content-type', 'application/json')
       res.setHeader('Cache-Control', 'no-cache')
       res.setHeader('X-Radar-Host', hostname)
-
-
-
       if (versionNumber === 2) {
         res.end(JSON.stringify(monitor.getClientsOnline()) + '\n')
       } else {
@@ -136,8 +133,8 @@ function getPresence (req, res) {
       }
     })
   } else {
-    var scopes = q.scopes.split(','),
-      result = {}; // key: scope - value: replies
+    var scopes = q.scopes.split(',')
+    var result = {} // key: scope - value: replies
     scopes.forEach(function (scope) {
       var monitor = new PresenceManager('presence:/' + q.accountName + '/' + scope, {}, Presence.sentry)
       monitor.fullRead(function (online) {
@@ -146,7 +143,7 @@ function getPresence (req, res) {
         } else {
           result[scope] = online
         }
-        if (Object.keys(result).length == scopes.length) {
+        if (Object.keys(result).length === scopes.length) {
           res.setHeader('Content-type', 'application/json')
           res.setHeader('Cache-Control', 'no-cache')
           res.setHeader('X-Radar-Host', hostname)

--- a/api/lib/client.js
+++ b/api/lib/client.js
@@ -1,8 +1,8 @@
-var https = require('https'),
-  http = require('http'),
-  qs = require('querystring'),
-  urlmodule = require('url'),
-  logging = require('minilog')('client')
+var https = require('https')
+var http = require('http')
+var qs = require('querystring')
+var urlmodule = require('url')
+var logging = require('minilog')('client')
 
 function Scope (defaults) {
   // Clone Client.def. We don't want to change the defaults when we modify options further.
@@ -51,7 +51,7 @@ Client.prototype.header = function (key, value) {
 }
 
 Client.prototype.data = function (data) {
-  if (this.options.method == 'GET') {
+  if (this.options.method === 'GET') {
     // Append to QS
     logging.debug('GET append', data)
     this.options.path += '?' + qs.stringify(data)
@@ -71,11 +71,11 @@ Client.prototype.end = function (callback) {
 }
 
 Client.prototype._end = function (callback) {
-  var self = this,
-    options = this.options,
-    secure = this.options.secure,
-    resData = '',
-    protocol = (secure ? https : http)
+  var self = this
+  var options = this.options
+  var secure = this.options.secure
+  var resData = ''
+  var protocol = (secure ? https : http)
 
   if (this.beforeRequest) {
     this.beforeRequest(this)
@@ -86,10 +86,9 @@ Client.prototype._end = function (callback) {
     'request. Options: ', options)
 
   var proxy = protocol.request(options, function (response) {
-    response.on('data', function (chunk) { resData += chunk; })
+    response.on('data', function (chunk) { resData += chunk })
     response.on('end', function () {
-      var err,
-        isRedirect = Math.floor(response.statusCode / 100) == 3 && response.headers && response.headers.location
+      var isRedirect = Math.floor(response.statusCode / 100) === 3 && response.headers && response.headers.location
 
       logging.debug('Response for the request "' + options.method + ' ' + options.host + options.path + '" has been ended.')
 
@@ -102,7 +101,7 @@ Client.prototype._end = function (callback) {
         response.headers['content-type'].toLowerCase().indexOf('application/json') > -1) {
         try {
           resData = JSON.parse(resData)
-        } catch(jsonParseError) {
+        } catch (jsonParseError) {
           return self._error(jsonParseError, resData, callback)
         }
       }
@@ -124,9 +123,9 @@ Client.prototype._end = function (callback) {
         callback(undefined, resData)
       }
     })
-  }).on('error', function (err) { self._error(err, callback); })
+  }).on('error', function (err) { self._error(err, callback) })
 
-  if (options.data && options.method != 'GET') {
+  if (options.data && options.method !== 'GET') {
     proxy.write(options.data)
   }
 
@@ -142,18 +141,16 @@ Client.prototype._error = function (error, resData, callback) {
   }
 }
 
-Client.prototype._redirect = function (response) {
-  var parts
-
+Client.prototype._redirect = function (response, callback) {
   if (!/^https?:/.test(response.headers.location)) {
-    response.headers.location = urlmodule.resolve(options.url, response.headers.location)
+    response.headers.location = urlmodule.resolve(this.options.url, response.headers.location)
   }
 
   // Parse location to check for port
-  parts = urlmodule.parse(response.headers.location)
-  if (parts.protocol == 'http:') {
-    options.secure = false
-    options.port = parts.port || 80
+  var parts = urlmodule.parse(response.headers.location)
+  if (parts.protocol === 'http:') {
+    this.options.secure = false
+    this.options.port = parts.port || 80
   }
 
   this.options.url = parts.href

--- a/api/lib/router.js
+++ b/api/lib/router.js
@@ -1,5 +1,5 @@
-var url = require('url'),
-  logging = require('minilog')('radar:api-router')
+var url = require('url')
+var logging = require('minilog')('radar:api-router')
 
 function Router () {
   this.urlMap = []
@@ -9,13 +9,13 @@ function Router () {
 Router.prototype.route = function (req, res) {
   logging.info('Routing request "' + req.method + ' ' + req.url + '"')
 
-  var pathname = url.parse(req.url).pathname.replace(/^\/?node/, ''),
-    len = this.urlMap.length,
-    i = -1,
-    urlHandler
+  var pathname = url.parse(req.url).pathname.replace(/^\/?node/, '')
+  var len = this.urlMap.length
+  var i = -1
+  var urlHandler
 
-  while(++i <= len){
-    if (this.urlMap[i] && this.urlMap[i].method == req.method && this.urlMap[i].re.test(pathname)) {
+  while (++i <= len) {
+    if (this.urlMap[i] && this.urlMap[i].method === req.method && this.urlMap[i].re.test(pathname)) {
       urlHandler = this.urlMap[i]
       break
     }
@@ -25,7 +25,7 @@ Router.prototype.route = function (req, res) {
     return false
   }
 
-  if (req.method == 'POST') {
+  if (req.method === 'POST') {
     var data = ''
 
     req.on('data', function (chunk) {
@@ -34,14 +34,13 @@ Router.prototype.route = function (req, res) {
 
     req.on('end', function () {
       logging.debug('Post data sent to ' + req.url + ' ended.')
-      urlHandler.callback.apply(undefined, [req, res, urlHandler.re.exec(pathname), data ])
+      urlHandler.callback.apply(undefined, [req, res, urlHandler.re.exec(pathname), data])
     })
   } else {
-    urlHandler.callback.apply(undefined, [req, res, urlHandler.re.exec(pathname) ])
+    urlHandler.callback.apply(undefined, [req, res, urlHandler.re.exec(pathname)])
   }
 
   return true
-
 }
 
 Router.prototype.get = function (regexp, callback) {
@@ -53,9 +52,10 @@ Router.prototype.post = function (regexp, callback) {
 }
 
 Router.prototype.attach = function (httpServer) {
-  var self = this,
-    // Cache and clean up listeners
-    oldListeners = httpServer.listeners('request')
+  var self = this
+
+  // Cache and clean up listeners
+  var oldListeners = httpServer.listeners('request')
   httpServer.removeAllListeners('request')
 
   // Add request handler
@@ -67,7 +67,6 @@ Router.prototype.attach = function (httpServer) {
       }
     }
   })
-
 }
 
 module.exports = Router

--- a/client/client.js
+++ b/client/client.js
@@ -1,5 +1,4 @@
-var _ = require('underscore'),
-  log = require('minilog')('radar:client')
+var log = require('minilog')('radar:client')
 
 function Client (name, id, accountName, version) {
   this.createdAt = Date.now()
@@ -63,7 +62,7 @@ Client.prototype.storeData = function (messageIn) {
       break
   }
 
-  // FIXME: For now log everything Later, enable sample logging. 
+  // FIXME: For now log everything Later, enable sample logging
   if (processedOp) {
     this._logState()
   }
@@ -82,8 +81,8 @@ Client.prototype.readData = function (cb) {
 }
 
 Client.prototype._logState = function () {
-  var subCount = Object.keys(this.subscriptions).length,
-    presCount = Object.keys(this.presences).length
+  var subCount = Object.keys(this.subscriptions).length
+  var presCount = Object.keys(this.presences).length
 
   log.info('#storeData', {
     client_id: this.id,
@@ -93,9 +92,9 @@ Client.prototype._logState = function () {
 }
 
 Client.prototype._storeDataSubscriptions = function (messageIn) {
-  var message = _cloneForStorage(messageIn),
-    to = message.to,
-    existingSubscription
+  var message = _cloneForStorage(messageIn)
+  var to = message.to
+  var existingSubscription
 
   // Persist the message data, according to type
   switch (message.op) {
@@ -119,12 +118,12 @@ Client.prototype._storeDataSubscriptions = function (messageIn) {
 }
 
 Client.prototype._storeDataPresences = function (messageIn) {
-  var message = _cloneForStorage(messageIn),
-    to = message.to,
-    existingPresence
+  var message = _cloneForStorage(messageIn)
+  var to = message.to
+  var existingPresence
 
   // Persist the message data, according to type
-  if (message.op === 'set' && to.substr(0, 'presence:/'.length) == 'presence:/') {
+  if (message.op === 'set' && to.substr(0, 'presence:/'.length) === 'presence:/') {
     existingPresence = this.presences[to]
 
     // Should go offline

--- a/configuration.js
+++ b/configuration.js
@@ -43,5 +43,5 @@ module.exports = {
   // use_connection: 'legacy',
 
   // Radar config: Port for radar to run on.
-  port: 8000,
+  port: 8000
 }

--- a/configurator.js
+++ b/configurator.js
@@ -1,17 +1,17 @@
-/* 
- * Configurator: Handles configuration for the Radar server. 
+/*
+ * Configurator: Handles configuration for the Radar server.
  *
  * It provides the default configuration.
- * For each allowed variable, it provides a default, which can be overwritten 
- * through ENV or ARGV. 
- * 
- * All the knowledge of what comes in, belongs here. 
- * 
+ * For each allowed variable, it provides a default, which can be overwritten
+ * through ENV or ARGV
+ *
+ * All the knowledge of what comes in, belongs here
+ *
  * ARGV > ENV > DEFAULTS
  *
  */
 
-// Minimal radar settings. 
+// Minimal radar settings
 var defaultSettings = [
   {
     name: 'port', description: 'port to listen',
@@ -52,10 +52,10 @@ var Configurator = function (settings) {
 
 // Class methods
 
-// Creates a Configurator and returns loaded configuration. 
+// Creates a Configurator and returns loaded configuration
 Configurator.load = function () {
-  var configurator = new Configurator(),
-    configuration = configurator.load.apply(configurator, arguments)
+  var configurator = new Configurator()
+  var configuration = configurator.load.apply(configurator, arguments)
 
   return configuration
 }
@@ -63,11 +63,11 @@ Configurator.load = function () {
 // Instance methods
 
 Configurator.prototype.load = function () {
-  var self = this,
-    options = (arguments.length === 1 ? arguments[0] : {}),
-    cli = this._parseCli((options.argv || process.argv)),
-    env = this._parseEnv((options.env || process.env)),
-    config = this._defaultConfiguration()
+  var self = this
+  var options = (arguments.length === 1 ? arguments[0] : {})
+  var cli = this._parseCli((options.argv || process.argv))
+  var env = this._parseEnv((options.env || process.env))
+  var config = this._defaultConfiguration()
 
   merge(config, options.config)
 
@@ -99,8 +99,8 @@ Configurator.prototype._parseCli = function (argv) {
 }
 
 Configurator.prototype._parseEnv = function (env) {
-  var cleanEnv = {},
-    value
+  var cleanEnv = {}
+  var value
 
   this.settings.forEach(function (element) {
     value = env[element.env]
@@ -125,9 +125,9 @@ Configurator.prototype._defaultConfiguration = function () {
 }
 
 Configurator.prototype._pickFirst = function (propName) {
-  var values = [].slice.call(arguments, 1),
-    i = 0,
-    value
+  var values = [].slice.call(arguments, 1)
+  var i = 0
+  var value = null
 
   while (!value && i <= values.length) {
     if (values[i] && values[i][propName]) {
@@ -149,14 +149,13 @@ Configurator.prototype._forPersistence = function (configuration) {
     }
 
     connection = {
-      id: configuration.sentinelMasterName,
+      id: configuration.sentinelMasterName
     }
 
     connection.sentinels = configuration.sentinelUrls
       .split(',')
       .map(parseUrl)
-
-  } else { // Using standalone redis. 
+  } else { // Using standalone redis
     connection = parseUrl(configuration.redisUrl)
   }
 
@@ -169,7 +168,7 @@ Configurator.prototype._forPersistence = function (configuration) {
 }
 
 // Private methods
-// TODO: Move to Util module, or somewhere else. 
+// TODO: Move to Util module, or somewhere else
 
 function parseUrl (redisUrl) {
   var parsedUrl = require('url').parse(redisUrl)

--- a/core/index.js
+++ b/core/index.js
@@ -1,8 +1,8 @@
-var Resource = require('./lib/resources/resource'),
-  MessageList = require('./lib/resources/message_list'),
-  Presence = require('./lib/resources/presence'),
-  Status = require('./lib/resources/status'),
-  Stream = require('./lib/resources/stream')
+var Resource = require('./lib/resources/resource')
+var MessageList = require('./lib/resources/message_list')
+var Presence = require('./lib/resources/presence')
+var Status = require('./lib/resources/status')
+var Stream = require('./lib/resources/stream')
 
 module.exports = {
   Persistence: require('persistence'),

--- a/core/lib/resources/message_list/index.js
+++ b/core/lib/resources/message_list/index.js
@@ -1,6 +1,6 @@
-var Resource = require('../resource.js'),
-  Persistence = require('persistence'),
-  logger = require('minilog')('radar:message_list')
+var Resource = require('../resource.js')
+var Persistence = require('persistence')
+var logger = require('minilog')('radar:message_list')
 
 var default_options = {
   policy: {

--- a/core/lib/resources/presence/presence_manager.js
+++ b/core/lib/resources/presence/presence_manager.js
@@ -1,8 +1,8 @@
-var _ = require('underscore'),
-  PresenceStore = require('./presence_store.js'),
-  Persistence = require('persistence'),
-  Minilog = require('minilog'),
-  logging = Minilog('radar:presence_manager')
+var _ = require('underscore')
+var PresenceStore = require('./presence_store.js')
+var Persistence = require('persistence')
+var Minilog = require('minilog')
+var logging = Minilog('radar:presence_manager')
 
 function PresenceManager (scope, policy, sentry) {
   this.scope = scope
@@ -54,7 +54,7 @@ PresenceManager.prototype.setup = function () {
     logging.info('#presence - #sentry down with ' + socketIds.length +
       ' clients ', socketIds)
 
-    if (!socketIds.length) { return; }
+    if (!socketIds.length) { return }
 
     var destroyNextSocket = function () {
       if (self.destroying) {
@@ -115,14 +115,14 @@ PresenceManager.prototype.destroy = function () {
     delete this.sentryListener
   }
 
-  // Client issues a full read and then dies and destroy is called.
+  // Client issues a full read and then dies and destroy is called
   if (this.handleRedisReply) {
     this.handleRedisReply = function () {}
   }
 
   delete this.store
 }
-// FIXME: Method signature is getting unmanageable.  
+// FIXME: Method signature is getting unmanageable
 PresenceManager.prototype.addClient = function (socketId, userId, userType,
   userData, clientData, callback) {
   if (typeof (clientData) === 'function') {
@@ -138,7 +138,7 @@ PresenceManager.prototype.addClient = function (socketId, userId, userType,
     sentry: this.sentry.name
   }
 
-  if (clientData) { message.clientData = clientData; }
+  if (clientData) { message.clientData = clientData }
 
   // We might need the details before we actually do a store.add
   this.store.cacheAdd(socketId, message)
@@ -206,12 +206,12 @@ PresenceManager.prototype._implicitDisconnect = function (socketId, userId,
 }
 
 PresenceManager.prototype.processRedisEntry = function (message, callback) {
-  var store = this.store,
-    self = this,
-    sentry = this.sentry,
-    userId = message.userId,
-    socketId = message.clientId,
-    userType = message.userType
+  var store = this.store
+  var self = this
+  var sentry = this.sentry
+  var userId = message.userId
+  var socketId = message.clientId
+  var userType = message.userType
 
   logging.debug('#presence - processRedisEntry:', message, this.scope)
   callback = callback || function () {}
@@ -228,7 +228,7 @@ PresenceManager.prototype.processRedisEntry = function (message, callback) {
       // Orphan redis entry: silently remove from redis then remove from store
       // implicitly.
       Persistence.deleteHash(this.scope, userId + '.' + socketId)
-      self.handleOffline(socketId, userId, userType, false /*explicit*/)
+      self.handleOffline(socketId, userId, userType, false /* explicit */)
     }
     callback()
   } else {
@@ -295,14 +295,15 @@ PresenceManager.prototype.fullRead = function (callback) {
   this.handleRedisReply = function (replies) {
     logging.debug('#presence - fullRead replies', self.scope, replies)
     if (!replies) {
-      if (callback) callback(self.getOnline())
+      if (callback) { callback(self.getOnline()) }
       return
     }
 
-    var count = 0, keys = Object.keys(replies)
+    var count = 0
+    var keys = Object.keys(replies)
     var completed = function () {
       count++
-      if (count == keys.length) {
+      if (count === keys.length) {
         if (callback) callback(self.getOnline())
       }
     }
@@ -321,8 +322,8 @@ PresenceManager.prototype.fullRead = function (callback) {
 
 // Sync v1
 PresenceManager.prototype.getOnline = function () {
-  var result = {},
-    store = this.store
+  var result = {}
+  var store = this.store
 
   this.store.users().forEach(function (userId) {
     result[userId] = store.userTypeOf(userId)
@@ -333,16 +334,17 @@ PresenceManager.prototype.getOnline = function () {
 
 // Sync v2
 PresenceManager.prototype.getClientsOnline = function () {
-  var result = {},
-    store = this.store
+  var result = {}
+  var store = this.store
 
   function processMessage (message) {
     result[message.userId] = result[message.userId] || {
-        clients: {},
-        userType: message.userType
+      clients: {},
+      userType: message.userType
     }
 
-    var payload = _.extend({}, (message.userData || {}),
+    var payload = _.extend({},
+      (message.userData || {}),
       (message.clientData || {}))
 
     result[message.userId].clients[message.clientId] = payload

--- a/core/lib/resources/presence/presence_store.js
+++ b/core/lib/resources/presence/presence_store.js
@@ -1,5 +1,5 @@
-var _ = require('underscore'),
-  logging = require('minilog')('radar:presence_store')
+var _ = require('underscore')
+var logging = require('minilog')('radar:presence_store')
 
 function PresenceStore (scope) {
   this.scope = scope
@@ -23,8 +23,8 @@ PresenceStore.prototype.cacheRemove = function (socketId) {
 }
 
 PresenceStore.prototype.add = function (socketId, userId, userType, message) {
-  var store = this,
-    events = []
+  var self = this
+  var events = []
 
   logging.debug('#presence - store.add', userId, socketId, message, this.scope)
   this.cacheRemove(socketId)
@@ -47,15 +47,15 @@ PresenceStore.prototype.add = function (socketId, userId, userType, message) {
     }
   }
 
-  events.forEach(function (ev) {
-    logging.debug('#presence - store.emit', ev, message, store.scope)
-    store.emit(ev, message)
+  events.forEach(function (event) {
+    logging.debug('#presence - store.emit', event, message, self.scope)
+    self.emit(event, message)
   })
 }
 
 PresenceStore.prototype.remove = function (socketId, userId, message) {
-  var store = this,
-    events = []
+  var self = this
+  var events = []
 
   logging.debug('#presence - store.remove', userId, socketId, message, this.scope)
 
@@ -78,8 +78,8 @@ PresenceStore.prototype.remove = function (socketId, userId, message) {
   }
 
   events.forEach(function (ev) {
-    logging.debug('#presence - store.emit', ev, message, store.scope)
-    store.emit(ev, message)
+    logging.debug('#presence - store.emit', ev, message, self.scope)
+    self.emit(ev, message)
   })
 }
 
@@ -153,11 +153,12 @@ PresenceStore.prototype.userExists = function (userId) {
 // this code uses each socketId in a separate chained call, the sum of which is
 // costly.
 PresenceStore.prototype.socketsForSentry = function (sentry) {
-  var map = this.map, socketIds = []
+  var map = this.map
+  var socketIds = []
   Object.keys(map).forEach(function (userId) {
     Object.keys(map[userId]).forEach(function (socketId) {
       var data = map[userId][socketId]
-      if (data && data.sentry == sentry) {
+      if (data && data.sentry === sentry) {
         socketIds.push(socketId)
       }
     })

--- a/core/lib/resources/presence/sentry.js
+++ b/core/lib/resources/presence/sentry.js
@@ -1,11 +1,11 @@
-var _ = require('underscore'),
-  Minilog = require('minilog'),
-  logging = Minilog('radar:sentry'),
-  Persistence = require('persistence'),
-  redisSentriesKey = 'sentry:/radar'
+var _ = require('underscore')
+var Minilog = require('minilog')
+var logging = Minilog('radar:sentry')
+var Persistence = require('persistence')
+var redisSentriesKey = 'sentry:/radar'
 
 var defaultOptions = {
-  EXPIRY_OFFSET: 60 * 1000, // 1 minute max valid time for an sentry message. 
+  EXPIRY_OFFSET: 60 * 1000, // 1 minute max valid time for an sentry message
   REFRESH_INTERVAL: 10000, // 10 seconds to refresh own sentry
   CHECK_INTERVAL: 30000 // 30 seconds to check for new sentries
 }
@@ -36,9 +36,9 @@ var Sentry = function (name) {
 require('util').inherits(Sentry, require('events').EventEmitter)
 
 Sentry.prototype.start = function (options, callback) {
-  var self = this,
-    keepAliveOptions = {},
-    upMessage
+  var self = this
+  var keepAliveOptions = {}
+  var upMessage
 
   options = options || {}
 
@@ -48,7 +48,7 @@ Sentry.prototype.start = function (options, callback) {
     this._applyOptions(options)
   }
 
-  if (this._refreshTimer) { return; }
+  if (this._refreshTimer) { return }
 
   logging.info('#presence - #sentry - starting', this.name)
 
@@ -63,7 +63,7 @@ Sentry.prototype.start = function (options, callback) {
     self.emit('up', self.name, upMessage)
     Persistence.publish(redisSentriesKey, upMessage)
     self._startListening()
-    if (callback) { callback(); }
+    if (callback) { callback() }
   })
 
   this._refreshTimer = setTimeout(this._refresh.bind(this), Math.floor(this._refreshInterval))
@@ -78,7 +78,7 @@ Sentry.prototype.stop = function (callback) {
   this.sentries = {}
   this._stopListening()
 
-  if (callback) { callback(); }
+  if (callback) { callback() }
 }
 
 Sentry.prototype.sentryNames = function () {
@@ -86,8 +86,8 @@ Sentry.prototype.sentryNames = function () {
 }
 
 Sentry.prototype.isDown = function (name) {
-  var lastMessage = this.sentries[name],
-    isSentryDown = messageIsExpired(lastMessage)
+  var lastMessage = this.sentries[name]
+  var isSentryDown = messageIsExpired(lastMessage)
 
   if (isSentryDown) {
     var text = this.messageExpirationText(lastMessage)
@@ -99,8 +99,8 @@ Sentry.prototype.isDown = function (name) {
 }
 
 Sentry.prototype.messageExpirationText = function (message) {
-  var expiration = messageExpiration(message),
-    text = expiration ? expiration + '/' + this._expiryOffset : 'not-present'
+  var expiration = messageExpiration(message)
+  var text = expiration ? expiration + '/' + this._expiryOffset : 'not-present'
 
   return text
 }
@@ -111,8 +111,8 @@ Sentry.prototype._setName = function (name) {
 }
 
 Sentry.prototype._generateName = function () {
-  var shasum = require('crypto').createHash('sha1'),
-    newName
+  var shasum = require('crypto').createHash('sha1')
+  var newName
 
   shasum.update(require('os').hostname() + ' ' + Math.random() + ' ' + Date.now())
   newName = shasum.digest('hex').slice(0, 15)
@@ -133,8 +133,8 @@ Sentry.prototype._applyOptions = function (options) {
 
 Sentry.prototype._keepAlive = function (options) {
   options = options || {}
-  var message = this._newKeepAliveMessage(options.name, options.expiration),
-    name = message.name
+  var message = this._newKeepAliveMessage(options.name, options.expiration)
+  var name = message.name
 
   this.sentries[name] = message
 
@@ -161,7 +161,7 @@ Sentry.prototype._expiryOffsetFromNow = function () {
 // It loads the sentries from redis, and performs two tasks:
 //
 // * purges sentries that are no longer available
-// * expire sentries based on stale messages. 
+// * expire sentries based on stale messages.
 //
 Sentry.prototype._loadAndCleanUpSentries = function (callback) {
   var self = this
@@ -179,7 +179,7 @@ Sentry.prototype._loadAndCleanUpSentries = function (callback) {
       }
     })
 
-    if (callback) { callback(); }
+    if (callback) { callback() }
   })
 }
 
@@ -194,21 +194,21 @@ Sentry.prototype._purgeSentry = function (name) {
   this.emit('down', name, lastMessage)
 }
 
-// Deletion of a gone sentry key might just happened, so 
+// Deletion of a gone sentry key might just happened, so
 // we compare existing sentry names to reply names
-// and clear whatever we have that no longer exists. 
+// and clear whatever we have that no longer exists.
 Sentry.prototype._purgeGoneSentries = function (replies, repliesKeys) {
-  var self = this,
-    sentriesGone = _.difference(this.sentryNames(), repliesKeys)
+  var self = this
+  var sentriesGone = _.difference(this.sentryNames(), repliesKeys)
 
   sentriesGone.forEach(function (name) {
     self._purgeSentry(name)
   })
 }
 
-// Listening for new pub sub messages from redis. 
-// As of now, we only care about new sentries going online. 
-// Everything else gets inferred based on time. 
+// Listening for new pub sub messages from redis.
+// As of now, we only care about new sentries going online.
+// Everything else gets inferred based on time.
 Sentry.prototype._startListening = function () {
   var self = this
 

--- a/core/lib/resources/resource.js
+++ b/core/lib/resources/resource.js
@@ -1,7 +1,6 @@
-var Persistence = require('persistence'),
-  MiniEventEmitter = require('miniee'),
-  logging = require('minilog')('radar:resource'),
-  Stamper = require('../../stamper.js')
+var MiniEventEmitter = require('miniee')
+var logging = require('minilog')('radar:resource')
+var Stamper = require('../../stamper.js')
 
 /*
 
@@ -134,7 +133,7 @@ Resource.prototype.handleMessage = function (socket, message) {
 Resource.prototype.destroy = function () {}
 
 Resource.setBackend = function (backend) {
-  Persistence = backend
+  // noop
 }
 
 module.exports = Resource

--- a/core/lib/resources/status/index.js
+++ b/core/lib/resources/status/index.js
@@ -1,6 +1,6 @@
-var Resource = require('../resource.js'),
-  Persistence = require('persistence'),
-  logger = require('minilog')('radar:status')
+var Resource = require('../resource.js')
+var Persistence = require('persistence')
+var logger = require('minilog')('radar:status')
 
 var default_options = {
   policy: {

--- a/core/lib/resources/stream/index.js
+++ b/core/lib/resources/stream/index.js
@@ -1,7 +1,7 @@
-var Resource = require('../resource.js'),
-  Persistence = require('persistence'),
-  logging = require('minilog')('radar:stream'),
-  SubscriberState = require('./subscriber_state.js')
+var Resource = require('../resource.js')
+var Persistence = require('persistence')
+var logging = require('minilog')('radar:stream')
+var SubscriberState = require('./subscriber_state.js')
 
 var default_options = {
   policy: {
@@ -33,9 +33,9 @@ Stream.prototype._getSyncError = function (from) {
 }
 
 Stream.prototype._subscribe = function (socket, message) {
-  var self = this,
-    from = message.options && message.options.from,
-    sub = this.subscriberState.get(socket.id)
+  var self = this
+  var from = message.options && message.options.from
+  var sub = this.subscriberState.get(socket.id)
 
   if (typeof from === 'undefined' || from < 0) {
     return
@@ -65,8 +65,8 @@ Stream.prototype.subscribe = function (socket, message) {
 }
 
 Stream.prototype.get = function (socket, message) {
-  var stream = this,
-    from = message && message.options && message.options.from
+  var stream = this
+  var from = message && message.options && message.options.from
   logging.debug('#stream - get', this.to, 'from: ' + from, (socket && socket.id))
 
   this._get(from, function (error, values) {
@@ -88,6 +88,7 @@ Stream.prototype.get = function (socket, message) {
 Stream.prototype._get = function (from, callback) {
   var self = this
   this.list.info(function (error, start, end, size) {
+    if (error) { return callback(error) }
     self.start = start
     self.end = end
     self.size = size
@@ -97,7 +98,6 @@ Stream.prototype._get = function (from, callback) {
 
 Stream.prototype.push = function (socket, message) {
   var self = this
-  var policy = this.options.policy || {}
 
   logging.debug('#stream - push', this.to, message, (socket && socket.id))
 
@@ -146,6 +146,6 @@ Stream.prototype.redisIn = function (data) {
   this.list.unblock()
 }
 
-Stream.setBackend = function (backend) { Persistence = backend; }
+Stream.setBackend = function (backend) { Persistence = backend }
 
 module.exports = Stream

--- a/core/lib/type.js
+++ b/core/lib/type.js
@@ -4,18 +4,18 @@ var Types = [
   {
     name: 'general message',
     type: 'MessageList',
-    expression: /^message:/,
+    expression: /^message:/
   },
   {
     name: 'general status',
     type: 'Status',
-    expression: /^status:/,
+    expression: /^status:/
   },
   {
     name: 'general presence',
     type: 'Presence',
     expression: /^presence:/,
-    policy: { cache: true, maxAgeSeconds: 15 },
+    policy: { cache: true, maxAgeSeconds: 15 }
   },
   {
     name: 'general stream',

--- a/core/stamper.js
+++ b/core/stamper.js
@@ -1,6 +1,6 @@
-var uuid = require('uuid'),
-  logging = require('minilog')('radar:stamper'),
-  sentryName
+var uuid = require('uuid')
+var logging = require('minilog')('radar:stamper')
+var sentryName
 
 module.exports = {
   setup: function (name) {

--- a/middleware/legacy_auth_manager.js
+++ b/middleware/legacy_auth_manager.js
@@ -1,11 +1,11 @@
 var logging = require('minilog')('radar:legacy_auth_manager')
 
-// Legacy auth middleware. 
+// Legacy auth middleware
 //
-// This middleware adds support for the legacy authentication process. 
+// This middleware adds support for the legacy authentication process.
 //
-// It checks for existance of an authProvider, and delegates 
-// authentication to it. 
+// It checks for existance of an authProvider, and delegates
+// authentication to it.
 //
 // {
 //    type: '...',
@@ -32,8 +32,8 @@ LegacyAuthManager.prototype.onMessage = function (socket, message, messageType, 
 }
 
 LegacyAuthManager.prototype.isAuthorized = function (socket, message, messageType) {
-  var isAuthorized = true,
-    provider = messageType && messageType.authProvider
+  var isAuthorized = true
+  var provider = messageType && messageType.authProvider
 
   if (provider && provider.authorize) {
     isAuthorized = provider.authorize(messageType, message, socket)

--- a/middleware/quota_limiter.js
+++ b/middleware/quota_limiter.js
@@ -1,5 +1,5 @@
-var logging = require('minilog')('radar:rate_limiter'),
-  MiniEventEmitter = require('miniee')
+var logging = require('minilog')('radar:rate_limiter')
+var MiniEventEmitter = require('miniee')
 
 var QuotaLimiter = function (limit) {
   this._limit = limit
@@ -42,7 +42,8 @@ QuotaLimiter.prototype.isAboveLimit = function (id, limit) {
 }
 
 QuotaLimiter.prototype.countAll = function () {
-  var counts = {}, self = this
+  var counts = {}
+  var self = this
 
   Object.keys(this._resources.id).forEach(function (id) {
     counts[id] = self.count(id)
@@ -113,7 +114,7 @@ QuotaLimiter.prototype._deepRemove = function (type, key, results, lookup) {
     Object.keys(results).forEach(function (result) {
       var keys = lookup.call(self, type, result)
 
-      if (keys) { delete keys[key]; }
+      if (keys) { delete keys[key] }
     })
   }
 }

--- a/middleware/quota_manager.js
+++ b/middleware/quota_manager.js
@@ -1,7 +1,7 @@
-var MiniEventEmitter = require('miniee'),
-  QuotaLimiter = require('./quota_limiter.js'),
-  Client = require('../client/client.js'),
-  logging = require('minilog')('radar:quota_manager')
+var MiniEventEmitter = require('miniee')
+var QuotaLimiter = require('./quota_limiter.js')
+var Client = require('../client/client.js')
+var logging = require('minilog')('radar:quota_manager')
 
 var QuotaManager = function () {
   this._limiters = {}
@@ -10,8 +10,8 @@ var QuotaManager = function () {
 MiniEventEmitter.mixin(QuotaManager)
 
 QuotaManager.prototype.checkLimits = function (socket, message, messageType, next) {
-  var limiter = this.getLimiter(messageType),
-    softLimit
+  var limiter = this.getLimiter(messageType)
+  var softLimit
 
   if (!limiter || (message.op !== 'subscribe' && message.op !== 'sync')) {
     next()
@@ -26,7 +26,7 @@ QuotaManager.prototype.checkLimits = function (socket, message, messageType, nex
 
     next(new Error('limit reached'))
   } else {
-    // Log Soft Limit, if available. 
+    // Log Soft Limit, if available
     softLimit = this._getSoftLimit(messageType)
     if (softLimit && limiter.count(socket.id) === softLimit) {
       var client = Client.get(socket.id)
@@ -66,8 +66,8 @@ QuotaManager.prototype.destroyByClient = function (socket, resource, messageType
 }
 
 QuotaManager.prototype.destroyByResource = function (resource, messageType, next) {
-  var to = resource.to,
-    limiter = this.findLimiter(messageType)
+  var to = resource.to
+  var limiter = this.findLimiter(messageType)
 
   if (limiter) {
     limiter.removeByTo(to)

--- a/middleware/runner.js
+++ b/middleware/runner.js
@@ -7,9 +7,9 @@ var Middleware = {
   },
 
   runMiddleware: function () {
-    var context = arguments[0],
-      args = [].slice.call(arguments, 1, -1),
-      callback = [].slice.call(arguments, -1)[0]
+    var context = arguments[0]
+    var args = [].slice.call(arguments, 1, -1)
+    var callback = [].slice.call(arguments, -1)[0]
 
     if (!this._middleware) {
       callback()
@@ -30,7 +30,8 @@ var Middleware = {
 
 module.exports = {
   mixin: function (receiver) {
-    var o = Middleware, k
+    var o = Middleware
+    var k
     for (k in o) {
       if (o.hasOwnProperty(k)) {
         receiver.prototype[k] = o[k]

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "radar_client": "^0.14.6",
     "simple_sentinel": "^0.1.8",
     "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "standard": "^5.4.1"
   },
   "scripts": {
     "prestart": "npm run check-modules",
@@ -59,7 +60,8 @@
     "check-clean": "if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != \"\" ]]; then npm run warn-dirty-tree && exit 1; fi",
     "warn-outdated": "echo 'Your node_modules are out of date. Please run \"rm -rf node_modules && npm install\" in order to ensure you have the latest dependencies.'",
     "warn-dirty-tree": "echo 'Your repo tree is dirty.'",
-    "pretest": "npm run check-modules",
+    "lint": "standard",
+    "pretest": "npm run check-modules && npm run lint",
     "test": "npm run test-sentinel",
     "test-full": "npm run test-sentinel && npm run test-redis",
     "test-redis": "ls ./tests/*.test.js | xargs -n 1 -t -I {} sh -c 'TEST=\"{}\" npm run test-one'",
@@ -69,5 +71,8 @@
     "test-one": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --timeout 4000ms --bail \"$TEST\"",
     "test-one-solo": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --timeout 4000ms --bail",
     "test-debug": "./node_modules/.bin/mocha debug --ui exports --reporter spec --slow 4000ms --bail \"$TEST\""
+  },
+  "standard": {
+    "ignore": ["sample/"]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,8 @@ run against redis and sentinel (longer).
 
 - Fork http://github.com/zendesk/radar, clone, make changes (including a Changelog update), commit, push, PR
 
+[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
+
 ## Copyright and License
 
 Copyright 2015, Zendesk Inc.

--- a/sample/server.js
+++ b/sample/server.js
@@ -1,10 +1,9 @@
-var fs = require('fs'),
-  url = require('url'),
-  http = require('http'),
+var fs = require('fs')
+var http = require('http')
 
-  Minilog = require('minilog'),
-  Radar = require('../index.js').server
-Router = require('../api/lib/router.js')
+var Minilog = require('minilog')
+var Radar = require('../index.js').server
+var Router = require('../api/lib/router.js')
 
 var server = http.createServer(function (req, res) {
   console.log('404', req.url)

--- a/sample/views.js
+++ b/sample/views.js
@@ -1,3 +1,4 @@
+/* globals RadarClient */
 function Status (elId) {
   this.elId = elId
   this.value = ''
@@ -35,7 +36,6 @@ OnlineToggle.prototype.render = function () {
   this.el || (this.el = document.getElementById(this.elId))
   var status = (model.online[RadarClient.configuration('userId')] ? 'offline' : 'online')
   this.el.innerHTML = '<a onclick="RadarClient.presence(\'foo\').set(\'' + status + '\');" href="javascript:;">Go ' + status + '</a>'
-
 }
 
 function MessageList (elId) {
@@ -51,29 +51,29 @@ MessageList.prototype.render = function () {
   this.el.innerHTML = '<ul>' + str + '</ul>'
 }
 
-model = {
+var model = {
   online: {},
   messages: []
 }
 
-function onlineUpdate (message) {
-  if (message.op != 'online' && message.op != 'offline') return
-  for (var userId in message.value) {
-    if (!message.value.hasOwnProperty(userId)) continue
-    model.online[userId] = !!(message.op == 'online')
-  }
-}
+// function onlineUpdate (message) {
+//   if (message.op !== 'online' && message.op !== 'offline') return
+//   for (var userId in message.value) {
+//     if (!message.value.hasOwnProperty(userId)) continue
+//     model.online[userId] = !!(message.op === 'online')
+//   }
+// }
 
-view = {
-  status: new Status('info'),
-  online: new OnlineList('online'),
-  toggle: new OnlineToggle('toggle'),
-  messages: new MessageList('messages')
-}
+// var view = {
+//   status: new Status('info'),
+//   online: new OnlineList('online'),
+//   toggle: new OnlineToggle('toggle'),
+//   messages: new MessageList('messages')
+// }
 
-function redraw () {
-  Object.keys(view).forEach(function (name) {
-    var view = window.view[name]
-    view.render()
-  })
-}
+// function redraw () {
+//   Object.keys(view).forEach(function (name) {
+//     var view = window.view[name]
+//     view.render()
+//   })
+// }

--- a/server.js
+++ b/server.js
@@ -1,8 +1,8 @@
-var http = require('http'),
-  configuration = require('./configurator.js').load({persistence: true}),
-  Radar = require('./server/server.js'),
-  Api = require('./api/api.js'),
-  Minilog = require('minilog')
+var http = require('http')
+var configuration = require('./configurator.js').load({persistence: true})
+var Radar = require('./server/server.js')
+var Api = require('./api/api.js')
+var Minilog = require('minilog')
 
 // Configure log output
 Minilog.pipe(Minilog.suggest.deny(/.*/, (process.env.radar_log ? process.env.radar_log : 'debug')))

--- a/tests/client.auth.test.js
+++ b/tests/client.auth.test.js
@@ -1,11 +1,7 @@
-var http = require('http'),
-  assert = require('assert'),
-  Radar = require('../server/server.js'),
-  Client = require('radar_client').constructor,
-  Type = require('../core').Type,
-  common = require('./common.js'),
-  Tracker = require('callback_tracker'),
-  Persistence = require('persistence')
+/* globals describe, it, before, after, afterEach */
+var assert = require('assert')
+var common = require('./common.js')
+var Persistence = require('persistence')
 
 describe('auth test', function () {
   var radar, client
@@ -62,7 +58,7 @@ describe('auth test', function () {
 
   describe('if type is not disabled', function () {
     it('should work', function (done) {
-      var originalMessage = { hello: 'world', timestamp: Date.now()}
+      var originalMessage = {hello: 'world', timestamp: Date.now()}
 
       client.message('enabled').on(function (message) {
         assert.deepEqual(message.value, originalMessage)

--- a/tests/client.connect.test.js
+++ b/tests/client.connect.test.js
@@ -1,8 +1,9 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  Client = require('radar_client').constructor,
-  Tracker = require('callback_tracker'),
-  radar, client
+/* globals describe, it, afterEach, before, after */
+var common = require('./common.js')
+var assert = require('assert')
+var Tracker = require('callback_tracker')
+var radar
+var client
 
 describe('Once radar server is running', function () {
   before(function (done) {

--- a/tests/client.message.test.js
+++ b/tests/client.message.test.js
@@ -1,8 +1,7 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  Persistence = require('../core').Persistence,
-  Client = require('radar_client').constructor,
-  Tracker = require('callback_tracker')
+/* globals describe, it, beforeEach, before, after */
+var common = require('./common.js')
+var assert = require('assert')
+var Tracker = require('callback_tracker')
 
 describe('When using message list resources:', function () {
   var radar, client, client2
@@ -57,7 +56,7 @@ describe('When using message list resources:', function () {
 
     // Sending a message should only send to each subscriber, but only once
     it('should receive a message only once per subscriber', function (done) {
-      var message = { state: 'test1'}
+      var message = {state: 'test1'}
 
       var finished = {}
 
@@ -87,16 +86,16 @@ describe('When using message list resources:', function () {
       // Send three messages, client2 will assert if it receieves any
       // Stop test when we receive all three at client 1
 
-      var message = { state: 'test1'},
-        message2 = { state: 'test2' },
-        message3 = { state: 'test3' }
+      var message = { state: 'test1' }
+      var message2 = { state: 'test2' }
+      var message3 = { state: 'test3' }
 
       client2.message('test').on(function (msg) {
         assert.ok(false)
       })
 
       client.message('test').on(function (msg) {
-        if (msg.value.state == 'test3') {
+        if (msg.value.state === 'test3') {
           done()
         }
       })
@@ -111,9 +110,9 @@ describe('When using message list resources:', function () {
       // client2 will assert if it receives message 2 and 3
       // Stop test when we receive all three at client 1
 
-      var message = { state: 'test1'}
-      var message2 = { state: 'test2'}
-      var message3 = { state: 'test3'}
+      var message = {state: 'test1'}
+      var message2 = {state: 'test2'}
+      var message3 = {state: 'test3'}
 
       // test.numAssertions = 3
       client2.message('test').on(function (msg) {
@@ -123,7 +122,7 @@ describe('When using message list resources:', function () {
       })
 
       client.message('test').on(function (msg) {
-        if (msg.value.state == 'test3') {
+        if (msg.value.state === 'test3') {
           // Received third message without asserting
           done()
         }
@@ -134,13 +133,12 @@ describe('When using message list resources:', function () {
     })
 
     it('should receive messages in the order of publish', function (done) {
-      var messages = ['1', '2', '3', '4', 'foobar', { foo: 'bar' }],
-        received = [],
-        assertions = 0
+      var messages = ['1', '2', '3', '4', 'foobar', { foo: 'bar' }]
+      var received = []
 
       client2.message('cached_chat/1').subscribe().on(function (m) {
         received.push(m)
-        if (received.length == 4) {
+        if (received.length === 4) {
           setTimeout(verify, 50)
         }
       })
@@ -186,10 +184,10 @@ describe('When using message list resources:', function () {
     })
 
     it('can publish an Object', function (done) {
-      var message = { state: 'other'}
+      var message = {state: 'other'}
 
       client.message('test').when(function (msg) {
-        if (msg.value && msg.value.state && msg.value.state == 'other') {
+        if (msg.value && msg.value.state && msg.value.state === 'other') {
           assert.equal('message:/dev/test', msg.to)
           assert.equal('other', msg.value.state)
           done()
@@ -223,8 +221,8 @@ describe('When using message list resources:', function () {
     })
 
     it('can sync() when messagelist has String', function (done) {
-      var message = 'foobar',
-        assertions = 0
+      var message = 'foobar'
+      var assertions = 0
       client2.message('cached_chat/1').subscribe()
         .publish(message)
         .once(function () {
@@ -243,8 +241,8 @@ describe('When using message list resources:', function () {
     })
 
     it('can sync() when messagelist has Object', function (done) {
-      var message = { foo: 'bar' },
-        assertions = 0
+      var message = { foo: 'bar' }
+      var assertions = 0
 
       client2.message('cached_chat/1').subscribe()
         .publish(message)
@@ -264,15 +262,15 @@ describe('When using message list resources:', function () {
     })
 
     it('can sync() with multiple values in correct order', function (done) {
-      var messages = ['1', '2', '3', '4', 'foobar', { foo: 'bar' }],
-        received = [],
-        written = 0,
-        assertions = 0
+      var messages = ['1', '2', '3', '4', 'foobar', { foo: 'bar' }]
+      var received = []
+      var written = 0
 
       client2.message('cached_chat/1').subscribe().on(function (m) {
         written++
-        if (written == messages.length)
+        if (written === messages.length) {
           syncTest()
+        }
       })
 
       for (var i = 0; i < messages.length; i++) {
@@ -282,7 +280,7 @@ describe('When using message list resources:', function () {
       function syncTest () {
         client.message('cached_chat/1').on(function (msg) {
           received.push(msg)
-          if (received.length == messages.length) {
+          if (received.length === messages.length) {
             setTimeout(function () {
               assert.equal(messages.length, received.length)
               for (var i = 0; i < received.length; i++) {

--- a/tests/client.presence.remote.test.js
+++ b/tests/client.presence.remote.test.js
@@ -1,19 +1,21 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  logging = require('minilog')('test'),
-  Persistence = require('../core').Persistence,
-  Tracker = require('callback_tracker'),
-  PresenceManager = require('../core/lib/resources/presence/presence_manager.js'),
-  Client = require('radar_client').constructor,
-  EE = require('events').EventEmitter,
-  AssertHelper = require('./lib/assert_helper.js'),
-  PresenceMessage = AssertHelper.PresenceMessage,
-  presenceManagerForSentry = AssertHelper.presenceManagerForSentry
+/* globals describe, it, beforeEach, afterEach, before, after */
+var common = require('./common.js')
+var assert = require('assert')
+var Persistence = require('../core').Persistence
+var Tracker = require('callback_tracker')
+var PresenceManager = require('../core/lib/resources/presence/presence_manager.js')
+var AssertHelper = require('./lib/assert_helper.js')
+var PresenceMessage = AssertHelper.PresenceMessage
+var presenceManagerForSentry = AssertHelper.presenceManagerForSentry
 
-var radar, client, client2,
-  p, testSentry, presenceManager, track
+describe('given a client and a server', function () {
+  var client
+  var p
+  var presenceManager
+  var radar
+  var testSentry
+  var track
 
-describe('given a client and a server,', function () {
   before(function (done) {
     common.startPersistence(function () {
       radar = common.spawnRadar()
@@ -30,7 +32,6 @@ describe('given a client and a server,', function () {
   })
 
   beforeEach(function (done) {
-    notifications = []
     testSentry = AssertHelper.newTestSentry('test-sentry')
     presenceManager = new PresenceManager('presence:/dev/test', {}, testSentry)
     p = new PresenceMessage('dev', 'test')
@@ -69,7 +70,7 @@ describe('given a client and a server,', function () {
 
   describe('when listening to a presence,', function () {
     beforeEach(function (done) {
-      client.presence('test').on(p.notify).subscribe(function () { done(); })
+      client.presence('test').on(p.notify).subscribe(function () { done() })
     })
 
     describe('for incoming online messages,', function () {
@@ -99,7 +100,7 @@ describe('given a client and a server,', function () {
       })
 
       it('should ignore messages from dead servers (sentry expired and gone)', function (done) {
-        presenceManagerForSentry('dead', {dead: true }, function (pm) {
+        presenceManagerForSentry('dead', {dead: true}, function (pm) {
           pm.addClient('abc', 100, 2, { name: 'tester' })
         })
 
@@ -115,8 +116,8 @@ describe('given a client and a server,', function () {
         p.fail_on_any_message()
         setTimeout(done, 10)
       })
-
     })
+
     describe('for incoming offline messages,', function () {
       beforeEach(function (done) {
         presenceManager.addClient('abc', 100, 2, { name: 'tester' }, done)
@@ -315,7 +316,7 @@ describe('given a client and a server,', function () {
           done()
         }
 
-        presenceManagerForSentry('expired', { expiration: Date.now() - 10}, function (pm) {
+        presenceManagerForSentry('expired', {expiration: Date.now() - 10}, function (pm) {
           pm.addClient('klm', 400, 2, { name: 'tester4' }, function () {
             client.presence('test').on(p.notify).sync({ version: 2 }, function (message) {
               p.for_online_clients(clients.abc, clients.def)
@@ -415,7 +416,6 @@ describe('given a client and a server,', function () {
 
         p.fail_on_any_message()
       })
-
     })
   })
 })

--- a/tests/client.presence.sentry.test.js
+++ b/tests/client.presence.sentry.test.js
@@ -1,23 +1,22 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  logging = require('minilog')('test'),
-  Persistence = require('../core').Persistence,
-  Tracker = require('callback_tracker'),
-  PresenceManager = require('../core/lib/resources/presence/presence_manager.js'),
-  Client = require('radar_client').constructor,
-  EE = require('events').EventEmitter,
-  assertHelper = require('./lib/assert_helper.js'),
-  PresenceMessage = assertHelper.PresenceMessage,
-  Sentry = require('../core/lib/resources/presence/sentry.js'),
-  radar, client, client2
+/* globals describe, it, beforeEach, afterEach, before, after */
+var common = require('./common.js')
+var assert = require('assert')
+var Persistence = require('../core').Persistence
+var Tracker = require('callback_tracker')
+var PresenceManager = require('../core/lib/resources/presence/presence_manager.js')
+var assertHelper = require('./lib/assert_helper.js')
+var PresenceMessage = assertHelper.PresenceMessage
+var Sentry = require('../core/lib/resources/presence/sentry.js')
+var radar
+var client
 
 describe('given a client and a server,', function () {
-  var p,
-    sentry = new Sentry('test-sentry', assertHelper.SentryDefaults),
-    presenceManager = new PresenceManager('presence:/dev/test', {}, sentry),
-    publishClientOnline = function (client) {
-      presenceManager.addClient(client.clientId, client.userId, client.userType, client.userData)
-    }
+  var p
+  var sentry = new Sentry('test-sentry', assertHelper.SentryDefaults)
+  var presenceManager = new PresenceManager('presence:/dev/test', {}, sentry)
+  var publishClientOnline = function (client) {
+    presenceManager.addClient(client.clientId, client.userId, client.userType, client.userData)
+  }
 
   before(function (done) {
     common.startPersistence(function () {
@@ -85,7 +84,6 @@ describe('given a client and a server,', function () {
           sentry.stop()
           p.on(4, validate)
         }, 1000)
-
       })
 
       it('should still be online if sentry is alive', function (done) {

--- a/tests/client.presence.test.js
+++ b/tests/client.presence.test.js
@@ -1,11 +1,12 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  logging = require('minilog')('test'),
-  Persistence = require('../core').Persistence,
-  Tracker = require('callback_tracker'),
-  Client = require('radar_client').constructor,
-  PresenceMessage = require('./lib/assert_helper.js').PresenceMessage,
-  radar, client, client2
+/* globals describe, it, beforeEach, afterEach, before, after */
+var common = require('./common.js')
+var assert = require('assert')
+var Tracker = require('callback_tracker')
+var PresenceMessage = require('./lib/assert_helper.js').PresenceMessage
+var radar
+var client
+var client2
+var client3
 
 describe('given two clients and a presence resource', function () {
   var p
@@ -72,7 +73,6 @@ describe('given two clients and a presence resource', function () {
           setTimeout(done, 10)
         })
       })
-
     })
 
     describe('with a client subscribed', function () {
@@ -158,7 +158,6 @@ describe('given two clients and a presence resource', function () {
 
     it('does not implicitly subscribe to the presence', function (done) {
       p = p.for_client(client)
-      var presence = client.presence('test').on(p.notify)
       p.fail_on_any_message(0)
       client.presence('test').set('online', function () {
         setTimeout(done, 500)
@@ -230,28 +229,28 @@ describe('given two clients and a presence resource', function () {
 
       it('should send online notification only once for multiple set(online), unless updated clientData, ' +
         'but only if it differs', function (done) {
-          var clientData = { data: 2 },
-            clientData2 = { data: 3 }
+        var clientData = { data: 2 }
+        var clientData2 = { data: 3 }
 
-          client2.presence('test').on(p.notify)
-            .subscribe(function () {
-              client.presence('test').set('online')
-              client.presence('test').set('online', clientData)
-              client.presence('test').set('online', clientData2)
-              client.presence('test').set('online', clientData2)
-              setTimeout(done, 50)
-            })
-
-          p.fail_on_more_than(4)
-          p.on(4, function () {
-            p.for_client(client).assert_message_sequence([
-              [ 'online' ],
-              [ 'client_online' ],
-              [ 'client_updated', clientData ],
-              [ 'client_updated', clientData2 ]
-            ])
+        client2.presence('test').on(p.notify)
+          .subscribe(function () {
+            client.presence('test').set('online')
+            client.presence('test').set('online', clientData)
+            client.presence('test').set('online', clientData2)
+            client.presence('test').set('online', clientData2)
+            setTimeout(done, 50)
           })
+
+        p.fail_on_more_than(4)
+        p.on(4, function () {
+          p.for_client(client).assert_message_sequence([
+            [ 'online' ],
+            [ 'client_online' ],
+            [ 'client_updated', clientData ],
+            [ 'client_updated', clientData2 ]
+          ])
         })
+      })
 
       it('should send presence messages correctly when toggling back and forth', function (done) {
         var expected = []
@@ -341,7 +340,7 @@ describe('given two clients and a presence resource', function () {
 
         p.on(4, function () {
           p.for_client(client).assert_message_sequence(
-            [ 'online', 'client_online', 'client_implicit_offline', 'offline']
+            ['online', 'client_online', 'client_implicit_offline', 'offline']
           )
           done()
         })
@@ -518,7 +517,7 @@ describe('given two clients and a presence resource', function () {
       setTimeout(function () {
         // Hack a bit so that socketId is saved
         var clientId = client2.currentClientId()
-        client2.currentClientId = function () { return clientId; }
+        client2.currentClientId = function () { return clientId }
         // Disconnect, causing a request timeout or socket close
         client2.manager.close()
       }, 10)
@@ -544,7 +543,7 @@ describe('given two clients and a presence resource', function () {
 
       // Hack a bit so that socketId is saved
       var clientId = client.currentClientId()
-      client.currentClientId = function () { return clientId; }
+      client.currentClientId = function () { return clientId }
 
       client.dealloc('test')
       var time = Date.now()

--- a/tests/client.rate_limit.test.js
+++ b/tests/client.rate_limit.test.js
@@ -1,8 +1,10 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  Tracker = require('callback_tracker'),
-  PresenceMessage = require('./lib/assert_helper.js').PresenceMessage,
-  radar, client
+/* globals describe, it, beforeEach, afterEach, before, after */
+var common = require('./common.js')
+var assert = require('assert')
+var Tracker = require('callback_tracker')
+var PresenceMessage = require('./lib/assert_helper.js').PresenceMessage
+var radar
+var client
 
 describe('The Server', function () {
   var p
@@ -52,10 +54,10 @@ describe('The Server', function () {
     it('should handle decrement on unsubscribe ', function (done) {
       client.presence('limited1').subscribe(function () {
         client.presence('limited2').subscribe()
-        // Already received the err. 
+        // Already received the err
 
         client.presence('limited1').unsubscribe(function () {
-          client.presence('limited1').subscribe(function () { done(); })
+          client.presence('limited1').subscribe(function () { done() })
         })
       })
     })
@@ -63,9 +65,9 @@ describe('The Server', function () {
     it.skip('should reset rate on client disconnect', function (done) {
       client.presence('limited1').subscribe(function () {
         client.presence('limited2').subscribe()
-        // Already received the err. 
+        // Already received the err
         client.dealloc('test')
-        // we need to find a way to test client disconnect and reconnect. 
+        // we need to find a way to test client disconnect and reconnect
         done()
       })
     })

--- a/tests/client.reconnect.test.js
+++ b/tests/client.reconnect.test.js
@@ -1,11 +1,9 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  Radar = require('../server/server.js'),
-  Backoff = require('radar_client').Backoff,
-  logging = require('minilog')('test:reconnect'),
-  Persistence = require('../core').Persistence,
-  Tracker = require('callback_tracker'),
-  radar
+/* globals describe, it, beforeEach, afterEach, before, after */
+
+var common = require('./common.js')
+var assert = require('assert')
+var Tracker = require('callback_tracker')
+var radar
 
 describe('When radar server restarts', function () {
   var client, client2
@@ -49,7 +47,7 @@ describe('When radar server restarts', function () {
           assert.deepEqual({ 123: 0 }, message.value)
           done()
         })
-      }, 1000); // let's wait a little
+      }, 1000) // let's wait a little
     }
 
     client.presence('restore').set('online', function () {
@@ -59,12 +57,13 @@ describe('When radar server restarts', function () {
 
   it('reconnects existing clients', function (done) {
     this.timeout(4000)
-    var clientEvents = [], client2Events = []
-    var states = ['disconnected', 'connected', 'ready']
+    var clientEvents = []
+    var client2Events = []
 
+    var states = ['disconnected', 'connected', 'ready']
     states.forEach(function (state) {
-      client.once(state, function () { clientEvents.push(state); })
-      client2.once(state, function () { client2Events.push(state); })
+      client.once(state, function () { clientEvents.push(state) })
+      client2.once(state, function () { client2Events.push(state) })
     })
 
     common.restartRadar(radar, common.configuration, [client, client2], function () {
@@ -115,8 +114,8 @@ describe('When radar server restarts', function () {
     var messages = []
     var verifySubscriptions = function () {
       assert.equal(messages.length, 2)
-      assert.ok(messages.some(function (m) { return m.value == '1';}))
-      assert.ok(messages.some(function (m) { return m.value == '2';}))
+      assert.ok(messages.some(function (m) { return m.value === 'a1' }))
+      assert.ok(messages.some(function (m) { return m.value === 'a2' }))
       done()
     }
 
@@ -124,19 +123,18 @@ describe('When radar server restarts', function () {
       client2.alloc('test', function () {
         client.message('foo').on(function (msg) {
           messages.push(msg)
-          if (messages.length == 2) {
+          if (messages.length === 2) {
             // When we have enough, wait a while and check
             setTimeout(verifySubscriptions, 100)
           }
         }).sync()
 
-        client2.message('foo').publish('1', function () {
+        client2.message('foo').publish('a1', function () {
           common.restartRadar(radar, common.configuration, [client, client2], function () {
-            client.message('foo').publish('2')
+            client.message('foo').publish('a2')
           })
         })
       })
     })
   })
-
 })

--- a/tests/client.status.test.js
+++ b/tests/client.status.test.js
@@ -1,9 +1,11 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  Persistence = require('../core').Persistence,
-  Client = require('radar_client').constructor,
-  Tracker = require('callback_tracker'),
-  radar, client, client2
+/* globals describe, it, beforeEach, before, after */
+
+var common = require('./common.js')
+var assert = require('assert')
+var Tracker = require('callback_tracker')
+var radar
+var client
+var client2
 
 describe('When using status resources', function () {
   before(function (done) {
@@ -51,8 +53,8 @@ describe('When using status resources', function () {
 
     // Sending a message should only send to each subscriber, but only once
     it('should receive a message only once per subscriber', function (done) {
-      var message = { state: 'test1'},
-        finished = {}
+      var message = {state: 'test1'}
+      var finished = {}
 
       function validate (msg, client_name) {
         assert.equal('status:/dev/test', msg.to)
@@ -90,16 +92,16 @@ describe('When using status resources', function () {
       // Send three messages, client2 will assert if it receieves any
       // Stop test when we receive all three at client 1
 
-      var message = { state: 'test1'},
-        message2 = { state: 'test2' },
-        message3 = { state: 'test3' }
+      var message = { state: 'test1' }
+      var message2 = { state: 'test2' }
+      var message3 = { state: 'test3' }
 
       client2.status('test').on(function (msg) {
         assert.ok(false)
       })
 
       client.status('test').on(function (msg) {
-        if (msg.value.state == 'test3') {
+        if (msg.value.state === 'test3') {
           done()
         }
       })
@@ -114,9 +116,9 @@ describe('When using status resources', function () {
       // client2 will assert if it receives message 2 and 3
       // Stop test when we receive all three at client 1
 
-      var message = { state: 'test1'}
-      var message2 = { state: 'test2'}
-      var message3 = { state: 'test3'}
+      var message = {state: 'test1'}
+      var message2 = {state: 'test2'}
+      var message3 = {state: 'test3'}
 
       // test.numAssertions = 3
       client2.status('test').on(function (msg) {
@@ -126,7 +128,7 @@ describe('When using status resources', function () {
       })
 
       client.status('test').on(function (msg) {
-        if (msg.value.state == 'test3') {
+        if (msg.value.state === 'test3') {
           // Received third message without asserting
           done()
         }
@@ -221,7 +223,7 @@ describe('When using status resources', function () {
         }).sync(function (message) {
           // Sync is implemented as subscribe + get, hence the return op is "get"
           assert.equal('get', message.op)
-          assert.deepEqual({ 246: 'foo'}, message.value)
+          assert.deepEqual({246: 'foo'}, message.value)
           setTimeout(done, 50)
         })
       })
@@ -239,7 +241,7 @@ describe('When using status resources', function () {
         }).sync(function (message) {
           // Sync is implemented as subscribe + get, hence the return op is "get"
           assert.equal('get', message.op)
-          assert.deepEqual({ 123: 'foo'}, message.value)
+          assert.deepEqual({123: 'foo'}, message.value)
           client.status('test').set('bar')
         })
       })
@@ -249,7 +251,7 @@ describe('When using status resources', function () {
         client.status('test').sync(function (message) {
           // Sync is implemented as subscribe + get, hence the return op is "get"
           assert.equal('get', message.op)
-          assert.deepEqual({ 123: 'foo'}, message.value)
+          assert.deepEqual({123: 'foo'}, message.value)
           done()
         })
       })

--- a/tests/client.stream.test.js
+++ b/tests/client.stream.test.js
@@ -1,11 +1,13 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  Persistence = require('../core').Persistence,
-  Client = require('radar_client').constructor,
-  StreamMessage = require('./lib/assert_helper.js').StreamMessage,
-  Tracker = require('callback_tracker'),
-  logging = require('minilog')('test'),
-  radar, client, client2
+/* globals describe, it, beforeEach, before, after */
+
+var common = require('./common.js')
+var assert = require('assert')
+var StreamMessage = require('./lib/assert_helper.js').StreamMessage
+var Tracker = require('callback_tracker')
+var logging = require('minilog')('test')
+var radar
+var client
+var client2
 
 describe('When using the stream resource', function () {
   var s = new StreamMessage('dev', 'test')
@@ -16,8 +18,8 @@ describe('When using the stream resource', function () {
     radar.sendCommand('start', common.configuration, function () {
       client = common.getClient('dev', 123, 0, { name: 'tester1' }, track('client 1 ready'))
       client2 = common.getClient('dev', 246, 0, { name: 'tester2' }, track('client 2 ready'))
-      client.on('message:in', function (m) { logging.info('incoming', client.id, m); })
-      client2.on('message:in', function (m) { logging.info('incoming', client2.id, m); })
+      client.on('message:in', function (m) { logging.info('incoming', client.id, m) })
+      client2.on('message:in', function (m) { logging.info('incoming', client2.id, m) })
     })
   })
 
@@ -55,8 +57,8 @@ describe('When using the stream resource', function () {
 
     // Sending a message should only send to each subscriber, but only once
     it('should receive a message only once per subscriber', function (done) {
-      var message = { state: 'test1'},
-        finished = {}
+      var message = {state: 'test1'}
+      var finished = {}
 
       function validate (msg, client_name) {
         assert.ok(!finished[client_name])
@@ -92,9 +94,9 @@ describe('When using the stream resource', function () {
       // Send three messages, client2 will assert if it receieves any
       // Stop test when we receive all three at client 1
 
-      var message = { state: 'test1'},
-        message2 = { state: 'test2' },
-        message3 = { state: 'test3' }
+      var message = { state: 'test1' }
+      var message2 = { state: 'test2' }
+      var message3 = { state: 'test3' }
 
       client2.stream('test').on(function (msg) {
         assert.ok(false)
@@ -120,9 +122,9 @@ describe('When using the stream resource', function () {
       // client2 will assert if it receives message 2 and 3
       // Stop test when we receive all three at client 1
 
-      var message = { state: 'test1'}
-      var message2 = { state: 'test2'}
-      var message3 = { state: 'test3'}
+      var message = {state: 'test1'}
+      var message2 = {state: 'test2'}
+      var message3 = {state: 'test3'}
 
       // test.numAssertions = 3
       client2.stream('test').on(function (msg) {
@@ -224,7 +226,7 @@ describe('When using the stream resource', function () {
           s.assert_sync_error_notification(s.notifications[4], { start: 5, end: 6, size: 2, from: 4 })
           s.on(6, function () {
             s.for_sender(client2).assert_message_sequence([
-              [ 'ticket/1', 'open', 'seventh']
+              ['ticket/1', 'open', 'seventh']
             ], 5)
 
             done()
@@ -303,7 +305,7 @@ describe('When using the stream resource', function () {
       var once_push = function () {
         client.stream('test').get(function (message) {
           s.assert_get_response(message, [
-            [ 'ticket/1', 'open', { hello: 'world' }, client ],
+            [ 'ticket/1', 'open', { hello: 'world' }, client ]
           ])
           done()
         })

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -1,10 +1,13 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  Client = require('../client/client.js'),
-  Persistence = require('../core').Persistence,
-  client, subscriptions
+/* globals describe, it, beforeEach */
+var common = require('./common.js')
+var assert = require('assert')
+var Client = require('../client/client.js')
 
 describe('Client', function () {
+  var client
+  var presences
+  var subscriptions
+
   beforeEach(function (done) {
     common.startPersistence(done) // clean up
     client = new Client('joe', Math.random(), 'test', 1)
@@ -15,8 +18,8 @@ describe('Client', function () {
   describe('.storeData and .loadData', function () {
     describe('subscriptions', function () {
       it('should store subscribe operations', function (done) {
-        var to = 'presence:/test/account/ticket/1',
-          message = { to: to, op: 'subscribe' }
+        var to = 'presence:/test/account/ticket/1'
+        var message = { to: to, op: 'subscribe' }
 
         subscriptions[to] = message
 
@@ -32,8 +35,8 @@ describe('Client', function () {
       })
 
       it('should store sync as subscribes', function (done) {
-        var to = 'presence:/test/account/ticket/1',
-          message = { to: to, op: 'sync' }
+        var to = 'presence:/test/account/ticket/1'
+        var message = { to: to, op: 'sync' }
 
         subscriptions[to] = message
 
@@ -49,9 +52,9 @@ describe('Client', function () {
       })
 
       it('should remove subscriptions on unsubscribe', function (done) {
-        var to = 'presence:/test/account/ticket/1',
-          subscribe = { to: to, op: 'subscribe' },
-          unsubscribe = { to: to, op: 'unsubscribe' }
+        var to = 'presence:/test/account/ticket/1'
+        var subscribe = { to: to, op: 'subscribe' }
+        var unsubscribe = { to: to, op: 'unsubscribe' }
 
         client.storeData(subscribe)
         client.storeData(unsubscribe)
@@ -66,9 +69,9 @@ describe('Client', function () {
       })
 
       it('sync after subscribe, keeps the sync', function (done) {
-        var to = 'presence:/test/account/ticket/1',
-          subscribe = { to: to, op: 'subscribe' },
-          sync = { to: to, op: 'sync' }
+        var to = 'presence:/test/account/ticket/1'
+        var subscribe = { to: to, op: 'subscribe' }
+        var sync = { to: to, op: 'sync' }
 
         client.storeData(subscribe)
         client.storeData(sync)
@@ -85,9 +88,9 @@ describe('Client', function () {
       })
 
       it('subscribe after sync, keeps the sync', function (done) {
-        var to = 'presence:/test/account/ticket/1',
-          subscribe = { to: to, op: 'subscribe' },
-          sync = { to: to, op: 'sync' }
+        var to = 'presence:/test/account/ticket/1'
+        var subscribe = { to: to, op: 'subscribe' }
+        var sync = { to: to, op: 'sync' }
 
         client.storeData(sync)
         client.storeData(subscribe)
@@ -106,8 +109,8 @@ describe('Client', function () {
 
     describe('presences', function () {
       it('should store set online operations', function (done) {
-        var to = 'presence:/test/account/ticket/1',
-          message = { to: to, op: 'set', value: 'online' }
+        var to = 'presence:/test/account/ticket/1'
+        var message = { to: to, op: 'set', value: 'online' }
 
         client.storeData(message)
 
@@ -124,9 +127,9 @@ describe('Client', function () {
       })
 
       it('should remove presence when set offline', function (done) {
-        var to = 'presence:/test/account/ticket/1',
-          online = { to: to, op: 'set', value: 'online' },
-          offline = { to: to, op: 'set', value: 'offline' }
+        var to = 'presence:/test/account/ticket/1'
+        var online = { to: to, op: 'set', value: 'online' }
+        var offline = { to: to, op: 'set', value: 'offline' }
 
         client.storeData(online)
         client.storeData(offline)

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,14 +1,13 @@
-var http = require('http'),
-  logging = require('minilog')('common'),
-  formatter = require('./lib/formatter.js'),
-  Persistence = require('persistence'),
-  RadarServer = new require('../index.js').server,
-  configuration = require('../configurator.js').load({persistence: true}),
-  Sentry = require('../core/lib/resources/presence/sentry.js'),
-  Client = require('radar_client').constructor,
-  fork = require('child_process').fork,
-  Tracker = require('callback_tracker'),
-  radar
+var http = require('http')
+var logging = require('minilog')('common')
+var formatter = require('./lib/formatter')
+var Persistence = require('persistence')
+var RadarServer = require('../index.js').server
+var configuration = require('../configurator').load({persistence: true})
+var Sentry = require('../core/lib/resources/presence/sentry')
+var Client = require('radar_client').constructor
+var fork = require('child_process').fork
+var Tracker = require('callback_tracker')
 
 Sentry.expiry = 4000
 if (process.env.verbose) {
@@ -35,7 +34,7 @@ module.exports = {
       var listener = function (message) {
         message = JSON.parse(message)
         logging.debug('message received', message, action)
-        if (message.action == action) {
+        if (message.action === action) {
           if (callback) callback(message.error)
         }
       }
@@ -110,18 +109,18 @@ module.exports = {
       accountName: account,
       port: configuration.port,
       upgrade: false,
-      userData: userData,
+      userData: userData
     }).once('ready', done).alloc('test')
     return client
   },
   configuration: configuration,
 
-  // Create an in-process radar server, not a child process. 
+  // Create an in-process radar server, not a child process.
   createRadarServer: function (done) {
-    var notFound = function p404 (req, res) {},
-      httpServer = http.createServer(notFound)
+    var notFound = function p404 (req, res) {}
+    var httpServer = http.createServer(notFound)
 
-    radarServer = new RadarServer()
+    var radarServer = new RadarServer()
     radarServer.attach(httpServer, configuration)
 
     if (done) {

--- a/tests/configurator.test.js
+++ b/tests/configurator.test.js
@@ -1,11 +1,11 @@
 /* global describe, it */
 
-var assert = require('assert'),
-  noArgs = ['', ''],
-  noEnv = {},
-  Configurator = require('../configurator.js')
+var assert = require('assert')
+var noArgs = ['', '']
+var noEnv = {}
+var Configurator = require('../configurator.js')
 
-// Helper function. It tests multiple features of a given configuration option. 
+// Helper function. It tests multiple features of a given configuration option.
 function describeOptionTest (configurator, name, options) {
   describe('option: ' + name, function () {
     if (options.default) {
@@ -31,14 +31,14 @@ function describeOptionTest (configurator, name, options) {
 
     if (options.short) {
       it('short arg: ' + options.short, function () {
-        var config = configurator.load({ argv: ['', '', options.short, options.expected ] })
+        var config = configurator.load({ argv: ['', '', options.short, options.expected] })
         assert.equal(config[name], options.expected)
       })
     }
 
     if (options.long) {
       it('long arg: ' + options.long, function () {
-        var config = configurator.load({ argv: ['', '', options.long, options.expected ] })
+        var config = configurator.load({ argv: ['', '', options.long, options.expected] })
         assert.equal(config[name], options.expected)
       })
     }
@@ -73,7 +73,6 @@ describe('the Configurator', function () {
       assert.equal(8004, config.port)
       assert.equal('mymaster', config.sentinelMasterName)
     })
-
   })
 
   describe('default settings', function () {
@@ -110,13 +109,13 @@ describe('the Configurator', function () {
 
   describe('custom setting', function () {
     var newOption = {
-        name: 'testOption', description: 'test option',
-        env: 'RADAR_TEST',
-        abbr: 'e',
-        full: 'exp',
-        default: 'testDefault'
-      },
-      configurator = new Configurator([newOption])
+      name: 'testOption', description: 'test option',
+      env: 'RADAR_TEST',
+      abbr: 'e',
+      full: 'exp',
+      default: 'testDefault'
+    }
+    var configurator = new Configurator([newOption])
 
     describeOptionTest(configurator, 'testOption', {
       default: 'testDefault',
@@ -125,6 +124,5 @@ describe('the Configurator', function () {
       short: '-e',
       env: 'RADAR_TEST'
     })
-
   })
 })

--- a/tests/lib/assert_helper.js
+++ b/tests/lib/assert_helper.js
@@ -1,21 +1,21 @@
-var _ = require('underscore'),
-  assert = require('assert'),
-  EE = require('events').EventEmitter,
-  Sentry = require('../../core/lib/resources/presence/sentry.js'),
-  PresenceManager = require('../../core/lib/resources/presence/presence_manager.js'),
-  SentryDefaults = {
-    expiryOffset: 4000,
-    refreshInterval: 3500,
-    checkInterval: 5000
-  }
+var _ = require('underscore')
+var assert = require('assert')
+var EE = require('events').EventEmitter
+var Sentry = require('../../core/lib/resources/presence/sentry.js')
+var PresenceManager = require('../../core/lib/resources/presence/presence_manager.js')
+var SentryDefaults = {
+  expiryOffset: 4000,
+  refreshInterval: 3500,
+  checkInterval: 5000
+}
 
 var clone = function (object) {
   return JSON.parse(JSON.stringify(object))
 }
 
 var presenceManagerForSentry = function (name, options, callback) {
-  var tempSentry = newTestSentry(name),
-    pm = new PresenceManager('presence:/dev/test', {}, tempSentry)
+  var tempSentry = newTestSentry(name)
+  var pm = new PresenceManager('presence:/dev/test', {}, tempSentry)
 
   options = options || {}
 
@@ -101,9 +101,9 @@ PresenceMessage.prototype.assert_stamp = function (stamp) {
 // }
 
 PresenceMessage.prototype.assert_online = function (originalMessage) {
-  var value = {},
-    client = this.client,
-    message = clone(originalMessage)
+  var value = {}
+  var client = this.client
+  var message = clone(originalMessage)
 
   this.assert_stamp(message.stamp)
   delete message.stamp
@@ -124,9 +124,9 @@ PresenceMessage.prototype.assert_online = function (originalMessage) {
 //   value: { <user_id>:<user_type> }
 // }
 PresenceMessage.prototype.assert_offline = function (originalMessage) {
-  var value = {},
-    client = this.client,
-    message = clone(originalMessage)
+  var value = {}
+  var client = this.client
+  var message = clone(originalMessage)
 
   this.assert_stamp(message.stamp)
   delete message.stamp
@@ -136,7 +136,7 @@ PresenceMessage.prototype.assert_offline = function (originalMessage) {
   assert.deepEqual({
     to: this.scope,
     op: 'offline',
-    value: value,
+    value: value
   }, message)
 }
 // client_online:
@@ -150,13 +150,13 @@ PresenceMessage.prototype.assert_offline = function (originalMessage) {
 //   }
 // }
 PresenceMessage.prototype.assert_client_online = function (originalMessage) {
-  var client = this.client,
-    message = clone(originalMessage),
-    value = {
-      userId: client.userId,
-      clientId: client.clientId,
-      userData: client.userData
-    }
+  var client = this.client
+  var message = clone(originalMessage)
+  var value = {
+    userId: client.userId,
+    clientId: client.clientId,
+    userData: client.userData
+  }
 
   this.assert_stamp(message.stamp)
   delete message.stamp
@@ -171,14 +171,14 @@ PresenceMessage.prototype.assert_client_online = function (originalMessage) {
 PresenceMessage.prototype.assert_client_updated = function (originalMessage, clientData) {
   assert(clientData, 'client_updated is only triggered on new clientData. To assert it, you need to pass the expected clientData.')
 
-  var client = this.client,
-    message = clone(originalMessage),
-    value = {
-      userId: client.userId,
-      clientId: client.clientId,
-      userData: client.userData,
-      clientData: clientData
-    }
+  var client = this.client
+  var message = clone(originalMessage)
+  var value = {
+    userId: client.userId,
+    clientId: client.clientId,
+    userData: client.userData,
+    clientData: clientData
+  }
 
   this.assert_stamp(message.stamp)
   delete message.stamp
@@ -200,12 +200,12 @@ PresenceMessage.prototype.assert_client_updated = function (originalMessage, cli
 //   }
 // }
 PresenceMessage.prototype.assert_client_offline = function (originalMessage, explicit) {
-  var client = this.client,
-    message = clone(originalMessage),
-    value = {
-      userId: client.userId,
-      clientId: client.clientId
-    }
+  var client = this.client
+  var message = clone(originalMessage)
+  var value = {
+    userId: client.userId,
+    clientId: client.clientId
+  }
 
   this.assert_stamp(message.stamp)
   delete message.stamp
@@ -227,8 +227,10 @@ PresenceMessage.prototype.assert_client_implicit_offline = function (message) {
 }
 
 PresenceMessage.prototype.assert_message_sequence = function (list, from) {
-  var i, method, args,
-    messages = this.notifications.slice(from)
+  var i
+  var method
+  var args
+  var messages = this.notifications.slice(from)
 
   assert.equal(messages.length, list.length, 'mismatch ' + list + ' in messages received : ' + JSON.stringify(messages))
 
@@ -240,18 +242,20 @@ PresenceMessage.prototype.assert_message_sequence = function (list, from) {
       method = 'assert_' + list[i]
     }
 
-    this[method].call(this, messages[i], args)
+    this[method](messages[i], args)
   }
 }
 
 PresenceMessage.prototype.assert_onlines_received = function () {
+  var j
   for (j = 0; j < this.online_clients.length; j++) {
     var client = this.online_clients[j]
     var uid = client.userId
     var cid = client.clientId
     var type = client.userType
-    var udata = client.userData
-    var i, online_idx = -1, client_online_idx = -1
+    var i
+    var online_idx = -1
+    var client_online_idx = -1
 
     for (i = 0; i < this.notifications.length; i++) {
       var value = this.notifications[i].value
@@ -260,14 +264,14 @@ PresenceMessage.prototype.assert_onlines_received = function () {
         online_idx = i
         this.for_client(client).assert_online(this.notifications[i])
       }
-      if (value.userId == uid && value.clientId == cid) {
+      if (value.userId === uid && value.clientId === cid) {
         assert.equal(client_online_idx, -1)
         client_online_idx = i
         this.for_client(client).assert_client_online(this.notifications[i])
       }
     }
-    assert.ok(online_idx != -1)
-    assert.ok(client_online_idx != -1)
+    assert.ok(online_idx !== -1)
+    assert.ok(client_online_idx !== -1)
     assert.ok(client_online_idx > online_idx)
   }
 }
@@ -300,7 +304,7 @@ PresenceMessage.prototype.for_online_clients = function () {
 //   }
 //  }
 PresenceMessage.prototype.assert_get_response = function (message) {
-  clients = this.online_clients || []
+  var clients = this.online_clients || []
   var value = {}
 
   clients.forEach(function (client) {
@@ -329,8 +333,8 @@ PresenceMessage.prototype.assert_get_response = function (message) {
 //  }
 // }
 PresenceMessage.prototype.assert_get_v2_response = function (message, clientData) {
-  var value = {},
-    clients = this.online_clients || []
+  var value = {}
+  var clients = this.online_clients || []
 
   clients.forEach(function (client) {
     var userHash
@@ -368,7 +372,7 @@ PresenceMessage.prototype.assert_get_v2_response = function (message, clientData
 //   }
 //  }
 PresenceMessage.prototype.assert_sync_response = function (message) {
-  clients = this.online_clients || []
+  var clients = this.online_clients || []
   var value = {}
 
   clients.forEach(function (client) {
@@ -527,7 +531,8 @@ StreamMessage.prototype.assert_push_notification = function (message, resource, 
 }
 
 StreamMessage.prototype.assert_message_sequence = function (list, from) {
-  var i, messages = this.notifications.slice(from)
+  var i
+  var messages = this.notifications.slice(from)
   assert.equal(list.length, messages.length, 'mismatch in number of messages')
   for (i = 0; i < messages.length; i++) {
     var listEntry = list[i]
@@ -544,7 +549,8 @@ StreamMessage.prototype.assert_message_sequence = function (list, from) {
 
 StreamMessage.prototype.assert_get_response = function (response, list, idstart) {
   idstart = idstart || 1
-  var values = [], scope = this.scope
+  var values = []
+  var scope = this.scope
   for (var i = 0; i < list.length; i++) {
     var listEntry = list[i]
     assert.equal(listEntry.length, 4)
@@ -555,7 +561,7 @@ StreamMessage.prototype.assert_get_response = function (response, list, idstart)
       action: listEntry[1],
       value: listEntry[2],
       userData: listEntry[3].configuration('userData'),
-      id: idstart + i,
+      id: idstart + i
     })
   }
 

--- a/tests/lib/formatter.js
+++ b/tests/lib/formatter.js
@@ -12,14 +12,14 @@ formatter.write = function (name, level, args) {
   }
   var result = [].concat(args)
   for (i = 0; i < result.length; i++) {
-    if (result[i] && typeof result[i] == 'object') {
+    if (result[i] && typeof result[i] === 'object') {
       // Buffers in Node.js look bad when stringified
       if (result[i].constructor && result[i].constructor.isBuffer) {
         result[i] = result[i].toString()
       } else {
         try {
           result[i] = JSON.stringify(result[i])
-        } catch(stringifyError) {
+        } catch (stringifyError) {
           // Happens when an object has a circular structure
           // Do not throw an error, when printing, the toString() method of the object will be used
         }

--- a/tests/lib/radar.js
+++ b/tests/lib/radar.js
@@ -1,20 +1,17 @@
-var http = require('http'),
-  Radar = require('../../index.js'),
-  configuration = require('../../configuration.js'),
-  PresenceManager = require('../../core/lib/resources/presence/presence_manager.js'),
-  Presence = require('../../core/lib/resources/presence/index.js'),
-  Sentry = require('../../core/lib/resources/presence/sentry.js'),
-  Middleware = require('../../middleware'),
-  QuotaManager = Middleware.QuotaManager,
-  LegacyAuthManager = Middleware.LegacyAuthManager,
-  Persistence = require('persistence'),
-  Type = require('../../core').Type,
-  Minilog = require('minilog'),
-  logger = Minilog('lib_radar'),
-  formatter = require('./formatter.js'),
-  assertHelper = require('./assert_helper.js'),
-  serverStarted = false,
-  radar, httpServer
+var http = require('http')
+var Radar = require('../../index.js')
+var Middleware = require('../../middleware')
+var QuotaManager = Middleware.QuotaManager
+var LegacyAuthManager = Middleware.LegacyAuthManager
+var Persistence = require('persistence')
+var Type = require('../../core').Type
+var Minilog = require('minilog')
+var logger = Minilog('lib_radar')
+var formatter = require('./formatter.js')
+var assertHelper = require('./assert_helper.js')
+var serverStarted = false
+var radar
+var httpServer
 
 if (process.env.verbose) {
   var minilogPipe = Minilog
@@ -41,7 +38,7 @@ Type.add([
     type: 'MessageList',
     policy: { cache: true, maxAgeSeconds: 30 },
     authProvider: {
-      authorize: function () { return false; }
+      authorize: function () { return false }
     }
   },
   {
@@ -49,7 +46,7 @@ Type.add([
     expression: /^message:\/client_auth\/enabled$/,
     type: 'MessageList',
     authProvider: {
-      authorize: function () { return true; }
+      authorize: function () { return true }
     }
   },
   { // For client.message.test
@@ -88,7 +85,7 @@ Type.add([
     policy: {
       limit: 1
     }
-  },
+  }
 ])
 
 var Service = {}
@@ -97,10 +94,10 @@ Service.start = function (configuration, callback) {
   logger.debug('creating radar', configuration)
   httpServer = http.createServer(p404)
 
-  // Add sentry defaults for testing. 
+  // Add sentry defaults for testing.
   configuration.sentry = assertHelper.SentryDefaults
-
-  radar = new Radar.server()
+  var RadarServer = Radar.server
+  radar = new RadarServer()
 
   radar.use(new QuotaManager())
   radar.use(new LegacyAuthManager())
@@ -120,6 +117,7 @@ Service.start = function (configuration, callback) {
 }
 
 Service.stop = function (arg, callback) {
+  var serverTimeout
   logger.info('stop')
 
   httpServer.on('close', function () {
@@ -141,7 +139,7 @@ Service.stop = function (arg, callback) {
       } else {
         logger.info('closing httpServer')
         logger.info('connections left', httpServer._connections)
-        var val = httpServer.close()
+        httpServer.close()
         serverTimeout = setTimeout(function () {
           // Failsafe, because server.close does not always
           // throw the close event within time.

--- a/tests/message_list.unit.test.js
+++ b/tests/message_list.unit.test.js
@@ -1,7 +1,8 @@
-var assert = require('assert'),
-  Common = require('./common'),
-  MessageList = require('../core/lib/resources/message_list'),
-  Persistence = require('persistence')
+/* globals describe, it, beforeEach, before, after */
+var assert = require('assert')
+var Common = require('./common')
+var MessageList = require('../core/lib/resources/message_list')
+var Persistence = require('persistence')
 
 describe('For a message list', function () {
   var message_list
@@ -45,7 +46,8 @@ describe('For a message list', function () {
 
     describe('if cache is set to true', function () {
       it('causes a broadcast and a write', function () {
-        var publishCalled = false, persistCalled = false
+        var publishCalled = false
+        var persistCalled = false
         FakePersistence.publish = function (key, message) {
           assert.equal('hello world', message)
           publishCalled = true
@@ -146,6 +148,8 @@ describe('For a message list', function () {
 
 describe('a message list resource', function () {
   describe('emitting messages', function () {
+    var radarServer
+
     beforeEach(function (done) {
       radarServer = Common.createRadarServer(done)
     })
@@ -166,10 +170,10 @@ describe('a message list resource', function () {
     })
 
     it('should emit outgoing messages', function (done) {
-      var subscribeMessage = { op: 'subscribe', to: 'message:/z1/test/ticket/1' },
-        publishMessage = { op: 'publish', to: 'message:/z1/test/ticket/1', value: {'type': 'activity','user_id': 123456789,'state': 4} },
-        socketOne = { id: 1, send: function (m) {} },
-        socketTwo = { id: 2, send: function (m) {} }
+      var subscribeMessage = { op: 'subscribe', to: 'message:/z1/test/ticket/1' }
+      var publishMessage = { op: 'publish', to: 'message:/z1/test/ticket/1', value: {'type': 'activity', 'user_id': 123456789, 'state': 4} }
+      var socketOne = { id: 1, send: function (m) {} }
+      var socketTwo = { id: 2, send: function (m) {} }
 
       radarServer.on('resource:new', function (resource) {
         resource.on('message:outgoing', function (message) {

--- a/tests/presence.remote.test.js
+++ b/tests/presence.remote.test.js
@@ -1,14 +1,15 @@
-var assert = require('assert'),
-  Persistence = require('persistence'),
-  Presence = require('../index.js').core.Presence,
-  Common = require('./common.js'),
-  readHashAll = Persistence.readHashAll,
-  Server = {
-    broadcast: function () {},
-    server: {
-      clients: { }
-    }
+/* globals */
+var assert = require('assert')
+var Persistence = require('persistence')
+var Presence = require('../index.js').core.Presence
+var Common = require('./common.js')
+var readHashAll = Persistence.readHashAll
+var Server = {
+  broadcast: function () {},
+  server: {
+    clients: { }
   }
+}
 
 exports['given a presence monitor'] = {
   beforeEach: function (done) {
@@ -41,10 +42,10 @@ exports['given a presence monitor'] = {
         })
         // Remote and local messages are treated differently
         // Namely, remote messages about local clients cannot trigger the fast path
-        presence.redisIn({ online: false, userId: 123, clientId: 'aab', userType: 0, sentry: Presence.sentry.name})
+        presence.redisIn({online: false, userId: 123, clientId: 'aab', userType: 0, sentry: Presence.sentry.name})
       })
     })
-    presence.redisIn({ online: true, userId: 123, clientId: 'aab', userType: 0, sentry: Presence.sentry.name})
+    presence.redisIn({online: true, userId: 123, clientId: 'aab', userType: 0, sentry: Presence.sentry.name})
   },
 
   'messages from Redis are not broadcast, only changes in status are': function () {
@@ -157,8 +158,8 @@ exports['given a presence monitor'] = {
     })
 
     this.presence.fullRead(function (online) {
-      assert.deepEqual({ 123: 0, 124: 2}, online)
-      assert.deepEqual({ 123: 0, 124: 2}, users)
+      assert.deepEqual({123: 0, 124: 2}, online)
+      assert.deepEqual({123: 0, 124: 2}, users)
       done()
     })
   },
@@ -167,12 +168,12 @@ exports['given a presence monitor'] = {
     // This may happen if the server gets terminated, so the key is never deleted properly...
     Persistence.readHashAll = function (scope, callback) {
       callback({
-        123: { online: true, userId: 123, userType: 0, clientId: 'aab', sentry: 'unknown'},
-        124: { online: true, userId: 124, userType: 2, clientId: 'bbb', sentry: Presence.sentry.name},
+        123: {online: true, userId: 123, userType: 0, clientId: 'aab', sentry: 'unknown'},
+        124: {online: true, userId: 124, userType: 2, clientId: 'bbb', sentry: Presence.sentry.name}
       })
     }
     this.presence.fullRead(function (online) {
-      assert.deepEqual({ 124: 2}, online)
+      assert.deepEqual({124: 2}, online)
       done()
     })
   },
@@ -180,15 +181,16 @@ exports['given a presence monitor'] = {
   'full reads cause change events based on what was previously known': function (done) {
     var presence = this.presence
     // Make 123 online
-    presence.redisIn({ online: true, userId: 123, userType: 0, clientId: 'aab', sentry: Presence.sentry.name })
+    presence.redisIn({online: true, userId: 123, userType: 0, clientId: 'aab', sentry: Presence.sentry.name})
 
     Persistence.readHashAll = function (scope, callback) {
       callback({
-        123: { online: false, userId: 123, userType: 0, clientId: 'aab', sentry: Presence.sentry.name},
-        124: { online: true, userId: 124, userType: 2, clientId: 'bbb', sentry: Presence.sentry.name },
+        123: {online: false, userId: 123, userType: 0, clientId: 'aab', sentry: Presence.sentry.name},
+        124: {online: true, userId: 124, userType: 2, clientId: 'bbb', sentry: Presence.sentry.name}
       })
     }
-    var added = {}, removed = {}
+    var added = {}
+    var removed = {}
     presence.manager.on('user_online', function (userId, userType) {
       added[userId] = userType
     })
@@ -197,9 +199,9 @@ exports['given a presence monitor'] = {
     })
 
     this.presence.fullRead(function (online) {
-      assert.deepEqual({ 123: 0}, removed)
-      assert.deepEqual({ 124: 2}, added)
-      assert.deepEqual({ 124: 2}, online)
+      assert.deepEqual({123: 0}, removed)
+      assert.deepEqual({124: 2}, added)
+      assert.deepEqual({124: 2}, online)
       done()
     })
   },
@@ -214,11 +216,12 @@ exports['given a presence monitor'] = {
         '200.sss': { online: false, userId: 200, userType: 2, clientId: 'sss', sentry: Presence.sentry.name },
         '200.1a': { online: false, userId: 200, userType: 2, clientId: '1a', sentry: Presence.sentry.name },
         '201.aaq': { online: false, userId: 201, userType: 4, clientId: 'aaq', sentry: Presence.sentry.name },
-        '201.www': { online: true, userId: 201, userType: 4, clientId: 'www', sentry: Presence.sentry.name },
+        '201.www': { online: true, userId: 201, userType: 4, clientId: 'www', sentry: Presence.sentry.name }
       })
     }
 
-    var added = {}, removed = {}
+    var added = {}
+    var removed = {}
     presence.manager.on('user_online', function (userId, userType) {
       added[userId] = userType
     })

--- a/tests/quota_limiter.test.js
+++ b/tests/quota_limiter.test.js
@@ -1,11 +1,12 @@
-var assert = require('assert'),
-  QuotaLimiter = require('../middleware').QuotaLimiter,
-  limit = 1,
-  clientId = '1',
-  clientId2 = '2',
-  toPrefix = 'presence://thing/',
-  to = toPrefix + '1',
-  quotaLimiter
+/* globals describe, it, beforeEach */
+var assert = require('assert')
+var QuotaLimiter = require('../middleware').QuotaLimiter
+var limit = 1
+var clientId = '1'
+var clientId2 = '2'
+var toPrefix = 'presence://thing/'
+var to = toPrefix + '1'
+var quotaLimiter
 
 describe('QuotaLimiter', function () {
   beforeEach(function () {
@@ -36,7 +37,7 @@ describe('QuotaLimiter', function () {
 
   it('duplicates should not count', function () {
     quotaLimiter.add(clientId, to)
-    assert(! quotaLimiter.add(clientId, to))
+    assert(!quotaLimiter.add(clientId, to))
     assert.equal(quotaLimiter.count(clientId), 1)
   })
 

--- a/tests/quota_manager.test.js
+++ b/tests/quota_manager.test.js
@@ -1,39 +1,40 @@
-var assert = require('assert'),
-  QuotaManager = require('../middleware').QuotaManager,
-  quotaManager,
-  client = {
-    id: 1,
-    send: function () {}
-  },
-  resource = {
-    to: 'scope'
-  },
-  limitedType = {
-    name: 'limited',
-    policy: { limit: 1 }
-  },
-  syncMessage = {
-    op: 'sync',
-    to: 'scope'
-  },
-  unsubscribeMessage = {
-    op: 'unsubscribe',
-    to: 'scope'
-  },
-  subscribeMessage = {
-    op: 'subscribe',
-    to: 'scope'
-  },
-  otherMessage = {
-    op: 'other',
-    to: 'scope'
-  }
+/* globals describe, it, beforeEach */
+var assert = require('assert')
+var QuotaManager = require('../middleware').QuotaManager
+var quotaManager
+var client = {
+  id: 1,
+  send: function () {}
+}
+var resource = {
+  to: 'scope'
+}
+var limitedType = {
+  name: 'limited',
+  policy: { limit: 1 }
+}
+var syncMessage = {
+  op: 'sync',
+  to: 'scope'
+}
+var unsubscribeMessage = {
+  op: 'unsubscribe',
+  to: 'scope'
+}
+var subscribeMessage = {
+  op: 'subscribe',
+  to: 'scope'
+}
+var otherMessage = {
+  op: 'other',
+  to: 'scope'
+}
 
 var assertLimitCount = function (manager, type, client, count, done) {
   var limiter = manager.getLimiter(type)
   assert(limiter)
   assert.equal(limiter.count(client.id), count)
-  if (done) { done(); }
+  if (done) { done() }
 }
 
 describe('QuotaManager', function () {
@@ -80,7 +81,7 @@ describe('QuotaManager', function () {
       quotaManager.updateLimits(client, resource, subscribeMessage, limitedType, function (err) {
         assert(err === undefined)
 
-        otherSubscribeMessage = { to: 'scope2', op: 'subscribe' }
+        var otherSubscribeMessage = { to: 'scope2', op: 'subscribe' }
         quotaManager.checkLimits(client, otherSubscribeMessage, limitedType, function (err) {
           assert(err)
           done()
@@ -92,7 +93,7 @@ describe('QuotaManager', function () {
       quotaManager.updateLimits(client, resource, syncMessage, limitedType, function (err) {
         assert(err === undefined)
 
-        otherSubscribeMessage = { to: 'scope2', op: 'subscribe' }
+        var otherSubscribeMessage = { to: 'scope2', op: 'subscribe' }
         quotaManager.checkLimits(client, otherSubscribeMessage, limitedType, function (err) {
           assert(err)
           done()
@@ -104,7 +105,7 @@ describe('QuotaManager', function () {
       quotaManager.updateLimits(client, resource, otherMessage, limitedType, function (err) {
         assert(err === undefined)
 
-        otherExtraMessage = { to: 'scope2', op: 'subscribe' }
+        var otherExtraMessage = { to: 'scope2', op: 'subscribe' }
         quotaManager.checkLimits(client, otherExtraMessage, limitedType, function (err) {
           assert(err === undefined)
           done()

--- a/tests/radar_api.test.js
+++ b/tests/radar_api.test.js
@@ -1,15 +1,15 @@
-var http = require('http'),
-  assert = require('assert'),
-  Api = require('../api/api.js'),
-  ClientScope = require('../api/lib/client'),
-  Persistence = require('../core').Persistence,
-  PresenceManager = require('../core').PresenceManager,
-  Presence = require('../core').Presence,
-  Type = require('../core').Type,
-  Status = require('../core').Status,
-  MessageList = require('../core').MessageList,
-  Common = require('./common.js'),
-  frontend
+var http = require('http')
+var assert = require('assert')
+var Api = require('../api/api.js')
+var ClientScope = require('../api/lib/client')
+var Persistence = require('../core').Persistence
+var PresenceManager = require('../core').PresenceManager
+var Presence = require('../core').Presence
+var Type = require('../core').Type
+var Status = require('../core').Status
+var MessageList = require('../core').MessageList
+var Common = require('./common.js')
+var frontend
 
 var originalSentry = Presence.sentry
 
@@ -23,7 +23,7 @@ exports['Radar api tests'] = {
   before: function (done) {
     Common.startPersistence(function () {
       // Create frontend server
-      frontend = http.createServer(function (req, res) { res.end('404 error');})
+      frontend = http.createServer(function (req, res) { res.end('404 error') })
       Api.attach(frontend)
 
       frontend.listen(8123, done)
@@ -41,9 +41,9 @@ exports['Radar api tests'] = {
 
   // GET /radar/status?accountName=test&scope=ticket/1
   'can get a status scope': function (done) {
-    var to = 'status:/test/ticket/1',
-      opts = Type.getByExpression(to),
-      status = new Status(to, {}, opts)
+    var to = 'status:/test/ticket/1'
+    var opts = Type.getByExpression(to)
+    var status = new Status(to, {}, opts)
 
     status.set({}, {
       key: 'foo',
@@ -52,9 +52,11 @@ exports['Radar api tests'] = {
 
     Client.get('/node/radar/status')
       .data({ accountName: 'test', scope: 'ticket/1' })
-      .end(function (error, response) {
+      .end(function (err, response) {
+        if (err) { return done(err) }
         assert.deepEqual({foo: 'bar'}, response)
         Persistence.ttl('status:/test/ticket/1', function (err, reply) {
+          if (err) { return done(err) }
           assert.ok((parseInt(reply, 10) > 0))
           done()
         })
@@ -65,20 +67,22 @@ exports['Radar api tests'] = {
   'can set a status scope': function (done) {
     Client.post('/node/radar/status')
       .data({ accountName: 'test', scope: 'ticket/2', key: 'foo', value: 'bar' })
-      .end(function (error, response) {
+      .end(function (err, response) {
+        if (err) { return done(err) }
         assert.deepEqual({}, response)
 
         Client.get('/node/radar/status')
           .data({ accountName: 'test', scope: 'ticket/2' })
-          .end(function (error, response) {
+          .end(function (err, response) {
+            if (err) { return done(err) }
             assert.deepEqual({foo: 'bar'}, response)
             Persistence.ttl('status:/test/ticket/2', function (err, reply) {
+              if (err) { return done(err) }
               assert.ok((parseInt(reply, 10) > 0))
               done()
             })
           })
       })
-
   },
 
   // GET /radar/message?accountName=test&scope=chat/1
@@ -92,9 +96,9 @@ exports['Radar api tests'] = {
 
     Type.register('message', message_type)
 
-    var to = 'message:/setStatus/chat/1',
-      opts = Type.getByExpression(to),
-      msgList = new MessageList(to, {}, opts)
+    var to = 'message:/setStatus/chat/1'
+    var opts = Type.getByExpression(to)
+    var msgList = new MessageList(to, {}, opts)
 
     msgList.publish({}, {
       key: 'foo',
@@ -104,6 +108,7 @@ exports['Radar api tests'] = {
     Client.get('/node/radar/message')
       .data({ accountName: 'setStatus', scope: 'chat/1' })
       .end(function (error, response) {
+        if (error) { return done(error) }
         assert.deepEqual({key: 'foo', value: 'bar'}, JSON.parse(response[0]))
         done()
       })
@@ -126,19 +131,21 @@ exports['Radar api tests'] = {
     Client.post('/node/radar/message')
       .data({ accountName: 'setStatus', scope: 'chat/2', value: 'hello' })
       .end(function (error, response) {
+        if (error) { return done(error) }
         assert.deepEqual({}, response)
 
         Client.get('/node/radar/message')
           .data({ accountName: 'setStatus', scope: 'chat/2' })
           .end(function (error, response) {
+            if (error) { return done(error) }
             assert.deepEqual('hello', JSON.parse(response[0]).value)
             Persistence.ttl('message:/setStatus/chat/2', function (err, reply) {
+              if (err) { return done(err) }
               assert.ok((parseInt(reply, 10) > 0))
               done()
             })
           })
       })
-
   },
 
   'given a fake PresenceMonitor': {
@@ -196,7 +203,8 @@ exports['Radar api tests'] = {
       Client.get('/node/radar/presence')
         .data({ accountName: 'test', scope: 'ticket/1' })
         .end(function (error, response) {
-          assert.deepEqual({'1': 0 }, response)
+          if (error) { return done(error) }
+          assert.deepEqual({'1': 0}, response)
           done()
         })
     },
@@ -205,7 +213,8 @@ exports['Radar api tests'] = {
       Client.get('/node/radar/presence')
         .data({ accountName: 'test', scopes: 'ticket/1,ticket/2' })
         .end(function (error, response) {
-          assert.deepEqual({ 'ticket/1': {'1': 0 }, 'ticket/2': {'2': 4}}, response)
+          if (error) { return done(error) }
+          assert.deepEqual({'ticket/1': {'1': 0}, 'ticket/2': {'2': 4}}, response)
           done()
         })
     },
@@ -214,7 +223,8 @@ exports['Radar api tests'] = {
       Client.get('/node/radar/presence')
         .data({ accountName: 'test', scope: 'ticket/1', version: 2 })
         .end(function (error, response) {
-          assert.deepEqual({'1': {'clients': {'1000': {}},'userType': 0}}, response)
+          if (error) { return done(error) }
+          assert.deepEqual({'1': {'clients': {'1000': {}}, 'userType': 0}}, response)
           done()
         })
     },
@@ -223,9 +233,10 @@ exports['Radar api tests'] = {
       Client.get('/node/radar/presence')
         .data({ accountName: 'test', scopes: 'ticket/1,ticket/2', version: 2 })
         .end(function (error, response) {
-          assert.deepEqual({ 'ticket/1': {'1': {'clients': {'1000': {}},'userType': 0}}, 'ticket/2': {'2': {'clients': {'1001': {}},'userType': 4}}}, response)
+          if (error) { return done(error) }
+          assert.deepEqual({'ticket/1': {'1': {'clients': {'1000': {}}, 'userType': 0}}, 'ticket/2': {'2': {'clients': {'1001': {}}, 'userType': 4}}}, response)
           done()
         })
-    },
+    }
   }
 }

--- a/tests/sentry.unit.test.js
+++ b/tests/sentry.unit.test.js
@@ -1,16 +1,20 @@
-var assert = require('assert'),
-  Tracker = require('callback_tracker'),
-  Sentry = require('../core/lib/resources/presence/sentry.js'),
-  Persistence = require('persistence'),
-  configuration = require('../configurator.js').load({persistence: true}),
-  _ = require('underscore'),
-  currentSentry = 0,
-  sentry, sentryOne, sentryTwo, sentryThree, sentries = [],
-  defaults = {
-    expiryOffset: 200,
-    refreshInterval: 100,
-    checkInterval: 200
-  }
+/* globals describe, it, beforeEach, afterEach, before */
+var assert = require('assert')
+var Sentry = require('../core/lib/resources/presence/sentry.js')
+var Persistence = require('persistence')
+var configuration = require('../configurator.js').load({persistence: true})
+var _ = require('underscore')
+var currentSentry = 0
+var sentry
+var sentryOne
+var sentryTwo
+var sentryThree
+var sentries = []
+var defaults = {
+  expiryOffset: 200,
+  refreshInterval: 100,
+  checkInterval: 200
+}
 
 function newSentry (options) {
   var name = 'sentry-' + currentSentry++
@@ -19,7 +23,7 @@ function newSentry (options) {
 }
 
 function assertSentriesKnowEachOther (sentries, done) {
-  var sentryNames = sentries.map(function (s) { return s.name; })
+  var sentryNames = sentries.map(function (s) { return s.name })
 
   sentries.forEach(function (sentry) {
     _.mapObject(sentry.sentries, function (message) {
@@ -27,7 +31,7 @@ function assertSentriesKnowEachOther (sentries, done) {
     })
   })
 
-  if (done) { done(); }
+  if (done) { done() }
 }
 
 describe('a Server Entry (Sentry)', function () {
@@ -38,8 +42,8 @@ describe('a Server Entry (Sentry)', function () {
 
   afterEach(function (done) {
     Persistence.redis().del('sentry:/radar', function () {
-      if (sentry) { sentry.stop(done); } else { done(); }
-      sentries.forEach(function (s) { s.stop(); })
+      if (sentry) { sentry.stop(done) } else { done() }
+      sentries.forEach(function (s) { s.stop() })
     })
   })
 
@@ -60,7 +64,6 @@ describe('a Server Entry (Sentry)', function () {
         assert.equal(sentry.isDown(sentry.name), false)
       })
     })
-
   })
 
   describe('keep alive', function () {
@@ -101,7 +104,7 @@ describe('a Server Entry (Sentry)', function () {
         setTimeout(function () {
           assert.equal(sentryOne.sentries[sentryTwo.name], undefined)
           done()
-        }, 300)
+        }, 500)
       }
 
       sentryTwo.stop(checkForSentryTwoGone)
@@ -110,8 +113,8 @@ describe('a Server Entry (Sentry)', function () {
 
   describe('complex scenario, with more than two sentries, when one dies', function () {
     it('all remaining sentries should do proper cleanup', function (done) {
-      sentryOne = newSentry({ checkInterval: 10})
-      sentryTwo = newSentry({ checkInterval: 20}); // It's important that sentryTwo is slower. 
+      sentryOne = newSentry({checkInterval: 10})
+      sentryTwo = newSentry({checkInterval: 20}) // It's important that sentryTwo is slower.
       sentryThree = newSentry()
       sentries = [ sentryOne, sentryTwo, sentryThree ]
 
@@ -119,7 +122,7 @@ describe('a Server Entry (Sentry)', function () {
         // stop one
         sentryThree.stop(function () {
           setTimeout(function () {
-            // assert existing sentries no longer know sentryThree. 
+            // assert existing sentries no longer know sentryThree.
             assert.equal(sentryOne.sentries[sentryThree.name], undefined)
             assert.equal(sentryTwo.sentries[sentryThree.name], undefined)
             done()
@@ -141,7 +144,7 @@ describe('a Server Entry (Sentry)', function () {
 
   describe('when emiting events', function () {
     it('should emit up when going up', function (done) {
-      sentryOne = newSentry({ checkInterval: 10})
+      sentryOne = newSentry({checkInterval: 10})
       sentryOne.on('up', function (name, message) {
         assert.equal(name, sentryOne.name)
         done()
@@ -164,7 +167,6 @@ describe('a Server Entry (Sentry)', function () {
           sentryTwo.stop()
         })
       })
-
     })
   })
 })

--- a/tests/server.auth.unit.test.js
+++ b/tests/server.auth.unit.test.js
@@ -1,30 +1,31 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  RadarTypes = require('../core/lib/type.js'),
-  controlMessage = {
-    to: 'control:/dev/test',
-    op: 'nameSync',
-    options: {
-      association: {
-        id: 1,
-        name: 1
-      }
+/* globals describe, it, beforeEach */
+var common = require('./common.js')
+var assert = require('assert')
+var RadarTypes = require('../core/lib/type.js')
+var controlMessage = {
+  to: 'control:/dev/test',
+  op: 'nameSync',
+  options: {
+    association: {
+      id: 1,
+      name: 1
     }
-  },
-  authProvider = {
-    authorize: function (channel, message, client) {
-      return false
-    }
-  },
-  authorizedType = {
-    name: 'general control',
-    type: 'Control',
-    authProvider: authProvider,
-    expression: /^control:/
-  },
-  LegacyAuthManager = require('../middleware').LegacyAuthManager,
-  radarServer,
-  socket
+  }
+}
+var authProvider = {
+  authorize: function (channel, message, client) {
+    return false
+  }
+}
+var authorizedType = {
+  name: 'general control',
+  type: 'Control',
+  authProvider: authProvider,
+  expression: /^control:/
+}
+var LegacyAuthManager = require('../middleware').LegacyAuthManager
+var radarServer
+var socket
 
 describe('given a server', function () {
   describe('without authentication', function () {
@@ -62,5 +63,4 @@ describe('given a server', function () {
       radarServer._processMessage(socket, controlMessage)
     })
   })
-
 })

--- a/tests/server.middleware.unit.test.js
+++ b/tests/server.middleware.unit.test.js
@@ -1,18 +1,18 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  RadarTypes = require('../core/lib/type.js'),
-  controlMessage = {
-    to: 'control:/dev/test',
-    op: 'nameSync',
-    options: {
-      association: {
-        id: 1,
-        name: 1
-      }
+/* globals describe, it, beforeEach, afterEach */
+var common = require('./common.js')
+var assert = require('assert')
+var controlMessage = {
+  to: 'control:/dev/test',
+  op: 'nameSync',
+  options: {
+    association: {
+      id: 1,
+      name: 1
     }
-  },
-  radarServer,
-  socket
+  }
+}
+var radarServer
+var socket
 
 describe('given a server with filters', function () {
   beforeEach(function (done) {

--- a/tests/server.unit.test.js
+++ b/tests/server.unit.test.js
@@ -1,13 +1,14 @@
-var common = require('./common.js'),
-  assert = require('assert'),
-  sinon = require('sinon'),
-  chai = require('chai'),
-  expect = chai.expect,
-  subscribeMessage = {
-    op: 'subscribe',
-    to: 'presence:/z1/test/ticket/1'
-  },
-  radarServer
+/* globals describe, it, beforeEach, afterEach*/
+var common = require('./common.js')
+var assert = require('assert')
+var sinon = require('sinon')
+var chai = require('chai')
+var expect = chai.expect
+var subscribeMessage = {
+  op: 'subscribe',
+  to: 'presence:/z1/test/ticket/1'
+}
+var radarServer
 
 chai.use(require('sinon-chai'))
 
@@ -85,8 +86,6 @@ describe('given a server', function () {
 
     socket.send = function (x) {}
 
-    var i = 0
-
     radarServer._handleResourceMessage = sinon.spy()
 
     radarServer._processMessage(socket, batchMessage)
@@ -95,15 +94,13 @@ describe('given a server', function () {
       expect(radarServer._handleResourceMessage).to.have.been.called.twice
       done()
     }, 20)
-
   })
 
   it('should stamp incoming messages', function (done) {
-    var called = false,
-      message = {
-        to: 'presence:/dev/test/ticket/1',
-        op: 'subscribe'
-      }
+    var message = {
+      to: 'presence:/dev/test/ticket/1',
+      op: 'subscribe'
+    }
 
     radarServer.on('resource:new', function (resource) {
       resource.subscribe(socket.id, { ack: 1 })

--- a/tests/stamper.test.js
+++ b/tests/stamper.test.js
@@ -1,7 +1,8 @@
-var assert = require('assert'),
-  Stamper = require('../core/stamper.js'),
-  sentryName = 'theSentryName',
-  clientId = 'clientId'
+/* globals describe, it */
+var assert = require('assert')
+var Stamper = require('../core/stamper.js')
+var sentryName = 'theSentryName'
+var clientId = 'clientId'
 
 Stamper.setup('theSentryName')
 
@@ -29,7 +30,7 @@ describe('a Stamper service', function () {
   })
 
   it('does not override id if present', function () {
-    var message = {stamp: { id: 1 } }
+    var message = {stamp: {id: 1}}
 
     Stamper.stamp(message, clientId)
 

--- a/tests/status.unit.test.js
+++ b/tests/status.unit.test.js
@@ -1,14 +1,15 @@
-var assert = require('assert'),
-  Status = require('../core/lib/resources/status'),
-  Persistence = require('persistence'),
-  Common = require('./common.js')
+/* globals describe, it, before, after, beforeEach, afterEach */
+var assert = require('assert')
+var Status = require('../core/lib/resources/status')
+var Persistence = require('persistence')
+var Common = require('./common.js')
 
 describe('given a status resource', function () {
   var status
   var FakePersistence = {
     read: function () {},
     publish: function () {},
-    expire: function () {},
+    expire: function () {}
   }
   var Radar = {
     broadcast: function () {}
@@ -157,7 +158,7 @@ describe('given a status resource', function () {
     it('can be overrided', function (done) {
       var options = {
         policy: {
-          maxPersistence: 24 * 60 * 60,
+          maxPersistence: 24 * 60 * 60
         }
       }
 
@@ -174,6 +175,8 @@ describe('given a status resource', function () {
 })
 
 describe('a status resource', function () {
+  var radarServer
+
   describe('emitting messages', function () {
     beforeEach(function (done) {
       radarServer = Common.createRadarServer(done)
@@ -199,10 +202,10 @@ describe('a status resource', function () {
     })
 
     it('should emit outgoing messages', function (done) {
-      var subscribeMessage = { op: 'subscribe', to: 'status:/z1/test/ticket/1' },
-        setMessage = { op: 'set', to: 'status:/z1/test/ticket/1', value: { 1: 2} },
-        socketOne = { id: 1, send: function (m) {} },
-        socketTwo = { id: 2, send: function (m) {} }
+      var subscribeMessage = {op: 'subscribe', to: 'status:/z1/test/ticket/1'}
+      var setMessage = {op: 'set', to: 'status:/z1/test/ticket/1', value: {1: 2}}
+      var socketOne = {id: 1, send: function (m) {}}
+      var socketTwo = {id: 2, send: function (m) {}}
 
       radarServer.on('resource:new', function (resource) {
         resource.on('message:outgoing', function (message) {


### PR DESCRIPTION
This PR reformats radar and test code to conform to [`standard`](http://standardjs.com) style. From their homepage:

> No decisions to make. No .eslintrc, .jshintrc, or .jscsrc files to manage. It just works.

> This module saves you (and others!) time in two ways:

> No configuration. The easiest way to enforce consistent style in your project. Just drop it in.

> Catch style errors before they're submitted in PRs. Saves precious code review time by eliminating back-and-forth between maintainer and contributor.

It adds the `standard` cli tool to the npm `pretest` script so it will run locally and on ci.

Required
======
- [ ] +1 from team

Risks
=====
- Medium: This PR affects a significant percentage of the lines of code in the project, mostly with small, mechanical transformations via `standard --format`. The existing test suite passes and additional manual testing verifies this. The changes individually are all very low risk.
