### PR TITLE
Encapsulate socket in client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - '0.10'
+- '4.2'
 services:
 - redis-server
 script:

--- a/client/client_session.js
+++ b/client/client_session.js
@@ -9,19 +9,37 @@ function ClientSession (name, id, accountName, version, transport) {
   this.createdAt = Date.now()
   this.lastModified = Date.now()
   this.name = name
+  this.accountName = accountName
   this.id = id
   this.subscriptions = {}
   this.presences = {}
-  this.version = version
+  this.version = version || '0.0.0'
   EventEmitter.call(this)
 
   this.transport = transport
   this._setupTransport()
+  clientsById[this.id] = this
 }
+
 inherits(ClientSession, EventEmitter)
 
 ClientSession.prototype._initialize = function (set) {
+  var self = this
 
+  if (set) {
+    Object.keys(set).forEach(function (key) {
+      self[key] = set[key]
+    })
+  }
+
+  if (this.state.can('initialize')) {
+    this.state.initialize()
+  }
+  this.lastModified = Date.now()
+}
+
+ClientSession.prototype._cleanup = function () {
+  delete clientsById[this.id]
 }
 
 // Instance methods
@@ -34,7 +52,9 @@ ClientSession.prototype._initialize = function (set) {
 // clientSession.send(message)
 
 ClientSession.prototype.send = function (message) {
-  this.transport.send(message)
+  var data = JSON.stringify(message)
+  log.info('#socket.message.outgoing', this.id, data)
+  this.transport.send(data)
 }
 
 // Persist subscriptions and presences when not already persisted in memory
@@ -77,9 +97,73 @@ ClientSession.prototype.readData = function (cb) {
 ClientSession.prototype._setupTransport = function () {
   var self = this
 
-  this.transport && this.transport.on && this.transport.on('message', function emitClientMessage (message) {
-    self.emit('message', message)
+  if (!this.transport || !this.transport.on) {
+    return
+  }
+
+  this.transport.on('message', function emitClientMessage (message) {
+    var decoded = self._decodeIncomingMessage(message)
+    if (!decoded) {
+      log.warn('#socket.message.incoming.decode - could not decode')
+      return
+    }
+    log.info('#socket.message.incoming', self.id, decoded)
+
+    switch (self.state.current) {
+      case 'initializing':
+      case 'ready':
+        self._initializeOnNameSync(decoded)
+        self.emit('message', decoded)
+        break
+    }
   })
+
+  this.transport.on('close', function () {
+    log.info('#socket - disconnect', self.id)
+    self.state.end()
+  })
+}
+
+ClientSession.prototype._initializeOnNameSync = function (message) {
+  if (message.op !== 'nameSync') { return }
+
+  log.info('#socket.message - nameSync', message, this.id)
+
+  this.send({ op: 'ack', value: message && message.ack })
+
+  var association = message.options.association
+
+  ClientNamesById[association.id] = association.name
+  ClientIdsByName[association.name] = this
+
+  log.info('create: association name: ' + association.name +
+    '; association id: ' + association.id)
+
+  // (name, id, accountName, version, transport)
+
+  this._initialize({
+    name: association.name,
+    accountName: message.accountName,
+    clientVersion: message.options.clientVersion
+  })
+}
+
+ClientSession.prototype._decodeIncomingMessage = function (message) {
+  var decoded
+  try {
+    decoded = JSON.parse(message)
+  } catch (e) {
+    log.warn('#clientSession.message - json parse error', e)
+    return
+  }
+
+  // Format check
+  if (!decoded || !decoded.op) {
+    log.warn('#socket.message - rejected', this.id, decoded)
+    return
+  }
+
+  return decoded
 }
 
 ClientSession.prototype._logState = function () {
@@ -153,23 +237,22 @@ function _cloneForStorage (messageIn) {
 }
 
 // TODO: move these to SessionManager
+var clientsById = {}
 var ClientIdsByName = {} // keyed by name
 var ClientNamesById = {} // keyed by id
 
 // (String) => ClientSession
 function getClientSessionBySocketId (id) {
-  var name = ClientNamesById[id]
-  if (name) {
-    return ClientIdsByName[name]
-  }
+  return clientsById[id]
 }
 
 // Set up client name/id association, and return new client instance
-function createClientSessionFromNameSyncMessage (message) {
+function createClientSessionFromNameSyncMessage (message, socket) {
   var association = message.options.association
   ClientNamesById[association.id] = association.name
+
   var clientSession = new ClientSession(association.name, association.id,
-    message.accountName, message.options.clientVersion)
+    message.accountName, message.options.clientVersion, socket)
 
   ClientIdsByName[association.name] = clientSession
 
@@ -179,6 +262,11 @@ function createClientSessionFromNameSyncMessage (message) {
   return clientSession
 }
 
+function createClientSessionFromSocket (socket) {
+  return new ClientSession(undefined, socket.id, undefined, undefined, socket)
+}
+
 module.exports = ClientSession
 module.exports.get = getClientSessionBySocketId
 module.exports.create = createClientSessionFromNameSyncMessage
+module.exports.createFromSocket = createClientSessionFromSocket

--- a/client/client_session.js
+++ b/client/client_session.js
@@ -1,8 +1,11 @@
 var log = require('minilog')('radar:client')
 var EventEmitter = require('events').EventEmitter
 var inherits = require('util').inherits
+var ClientSessionStateMachine = require('./client_session_state_machine')
 
 function ClientSession (name, id, accountName, version, transport) {
+  this.state = ClientSessionStateMachine.create(this)
+
   this.createdAt = Date.now()
   this.lastModified = Date.now()
   this.name = name
@@ -16,6 +19,10 @@ function ClientSession (name, id, accountName, version, transport) {
   this._setupTransport()
 }
 inherits(ClientSession, EventEmitter)
+
+ClientSession.prototype._initialize = function (set) {
+
+}
 
 // Instance methods
 

--- a/client/client_session_state_machine.js
+++ b/client/client_session_state_machine.js
@@ -1,0 +1,30 @@
+var StateMachine = require('javascript-state-machine')
+// var bind = require('lodash.bind')
+
+var bind = function (fn, context) {
+  return function () {
+    // parameters: event, from, to, ...args
+    var args = Array.prototype.slice.call(arguments, 3)
+    return fn.apply(context, args)
+  }
+}
+
+module.exports.create = function createClientSessionStateMachine (clientSession) {
+  return StateMachine.create({
+    initial: 'initializing',
+    events: [
+      {name: 'initialize', from: 'initializing', to: 'ready'},
+      {name: 'leave', from: 'ready', to: 'not ready'},
+      {name: 'comeback', from: 'not ready', to: 'ready'},
+      {name: 'end', from: ['ready', 'not ready'], to: 'ended'},
+      {name: 'abort', from: 'initializing', to: 'ended'}
+    ],
+    callbacks: {
+      oninitialize: bind(oninitialize, clientSession)
+    }
+  })
+}
+
+function oninitialize () {
+  console.log('oninitialize', arguments)
+}

--- a/client/client_session_state_machine.js
+++ b/client/client_session_state_machine.js
@@ -1,5 +1,4 @@
 var StateMachine = require('javascript-state-machine')
-// var bind = require('lodash.bind')
 
 var bind = function (fn, context) {
   return function () {
@@ -16,15 +15,20 @@ module.exports.create = function createClientSessionStateMachine (clientSession)
       {name: 'initialize', from: 'initializing', to: 'ready'},
       {name: 'leave', from: 'ready', to: 'not ready'},
       {name: 'comeback', from: 'not ready', to: 'ready'},
-      {name: 'end', from: ['ready', 'not ready'], to: 'ended'},
-      {name: 'abort', from: 'initializing', to: 'ended'}
+      {name: 'end', from: ['initializing', 'ready', 'not ready'], to: 'ended'}
     ],
     callbacks: {
-      oninitialize: bind(oninitialize, clientSession)
+      oninitialize: bind(oninitialize, clientSession),
+      onend: bind(onend, clientSession)
     }
   })
 }
 
 function oninitialize () {
-  console.log('oninitialize', arguments)
+  this.emit('initialize')
+}
+
+function onend () {
+  this._cleanup()
+  this.emit('end')
 }

--- a/core/lib/resources/resource.js
+++ b/core/lib/resources/resource.js
@@ -1,7 +1,7 @@
 var MiniEventEmitter = require('miniee')
 var logging = require('minilog')('radar:resource')
 var Stamper = require('../../stamper.js')
-
+var ClientSession = require('../../../client/client_session')
 /*
 
 Resources
@@ -100,11 +100,11 @@ Resource.prototype.redisIn = function (data) {
 // Return a socket reference; eio server hash is "clients", not "sockets"
 Resource.prototype.socketGet = function (id) {
   logging.debug('DEPRECATED: use clientSessionGet instead')
-  return this.server.socketServer.clients[id]
+  return this.getClientSession(id)
 }
 
 Resource.prototype.getClientSession = function (id) {
-  return this.server.socketServer.clients[id]
+  return ClientSession.get(id)
 }
 
 Resource.prototype.ack = function (clientSession, sendAck) {

--- a/core/lib/resources/resource.js
+++ b/core/lib/resources/resource.js
@@ -50,33 +50,33 @@ function Resource (to, server, options, default_options) {
 MiniEventEmitter.mixin(Resource)
 Resource.prototype.type = 'default'
 
-// Add a subscriber (Engine.io socket)
-Resource.prototype.subscribe = function (socket, message) {
-  this.subscribers[socket.id] = true
+// Add a subscriber (ClientSession)
+Resource.prototype.subscribe = function (clientSession, message) {
+  this.subscribers[clientSession.id] = true
 
-  logging.debug('#' + this.type, '- subscribe', this.to, socket.id,
+  logging.debug('#' + this.type, '- subscribe', this.to, clientSession.id,
     this.subscribers, message && message.ack)
 
-  this.ack(socket, message && message.ack)
+  this.ack(clientSession, message && message.ack)
 }
 
-// Remove a subscriber (Engine.io socket)
-Resource.prototype.unsubscribe = function (socket, message) {
-  delete this.subscribers[socket.id]
+// Remove a subscriber (ClientSession)
+Resource.prototype.unsubscribe = function (clientSession, message) {
+  delete this.subscribers[clientSession.id]
 
-  logging.info('#' + this.type, '- unsubscribe', this.to, socket.id,
+  logging.info('#' + this.type, '- unsubscribe', this.to, clientSession.id,
     'subscribers left:', Object.keys(this.subscribers).length)
 
   if (!Object.keys(this.subscribers).length) {
     logging.info('#' + this.type, '- destroying resource', this.to,
-      this.subscribers, socket.id)
+      this.subscribers, clientSession.id)
     this.server.destroyResource(this.to)
   }
 
-  this.ack(socket, message && message.ack)
+  this.ack(clientSession, message && message.ack)
 }
 
-// Send to Engine.io sockets
+// Send to clients
 Resource.prototype.redisIn = function (data) {
   var self = this
 
@@ -85,12 +85,12 @@ Resource.prototype.redisIn = function (data) {
   logging.info('#' + this.type, '- incoming from #redis', this.to, data, 'subs:',
     Object.keys(this.subscribers).length)
 
-  Object.keys(this.subscribers).forEach(function (socketId) {
-    var socket = self.socketGet(socketId)
+  Object.keys(this.subscribers).forEach(function (clientSessionId) {
+    var clientSession = self.getClientSession(clientSessionId)
 
-    if (socket && socket.send) {
-      data.stamp.clientId = socket.id
-      socket.send(data)
+    if (clientSession && clientSession.send) {
+      data.stamp.clientId = clientSession.id
+      clientSession.send(data)
     }
   })
 
@@ -99,21 +99,26 @@ Resource.prototype.redisIn = function (data) {
 
 // Return a socket reference; eio server hash is "clients", not "sockets"
 Resource.prototype.socketGet = function (id) {
+  logging.debug('DEPRECATED: use clientSessionGet instead')
   return this.server.socketServer.clients[id]
 }
 
-Resource.prototype.ack = function (socket, sendAck) {
-  if (socket && socket.send && sendAck) {
-    logging.debug('#socket - send_ack', socket.id, this.to, sendAck)
+Resource.prototype.getClientSession = function (id) {
+  return this.server.socketServer.clients[id]
+}
 
-    socket.send({
+Resource.prototype.ack = function (clientSession, sendAck) {
+  if (clientSession && clientSession.send && sendAck) {
+    logging.debug('#clientSession - send_ack', clientSession.id, this.to, sendAck)
+
+    clientSession.send({
       op: 'ack',
       value: sendAck
     })
   }
 }
 
-Resource.prototype.handleMessage = function (socket, message) {
+Resource.prototype.handleMessage = function (clientSession, message) {
   switch (message.op) {
     case 'subscribe':
     case 'unsubscribe':
@@ -122,11 +127,11 @@ Resource.prototype.handleMessage = function (socket, message) {
     case 'set':
     case 'publish':
     case 'push':
-      this[message.op](socket, message)
+      this[message.op](clientSession, message)
       this.emit('message:incoming', message)
       break
     default:
-      logging.error('#resource - Unknown message.op, ignoring', message, socket && socket.id)
+      logging.error('#resource - Unknown message.op, ignoring', message, clientSession && clientSession.id)
   }
 }
 

--- a/core/lib/resources/status/index.js
+++ b/core/lib/resources/status/index.js
@@ -16,13 +16,13 @@ Status.prototype = new Resource()
 Status.prototype.type = 'status'
 
 // Get status
-Status.prototype.get = function (socket) {
+Status.prototype.get = function (clientSession) {
   var to = this.to
 
-  logger.debug('#status - get', this.to, (socket && socket.id))
+  logger.debug('#status - get', this.to, (clientSession && clientSession.id))
 
   this._get(to, function (replies) {
-    socket.send({
+    clientSession.send({
       op: 'get',
       to: to,
       value: replies || {}
@@ -34,13 +34,13 @@ Status.prototype._get = function (to, callback) {
   Persistence.readHashAll(to, callback)
 }
 
-Status.prototype.set = function (socket, message) {
+Status.prototype.set = function (clientSession, message) {
   var self = this
 
-  logger.debug('#status - set', this.to, message, (socket && socket.id))
+  logger.debug('#status - set', this.to, message, (clientSession && clientSession.id))
 
   Status.prototype._set(this.to, message, this.options.policy, function () {
-    self.ack(socket, message.ack)
+    self.ack(clientSession, message.ack)
   })
 }
 
@@ -57,11 +57,11 @@ Status.prototype._set = function (scope, message, policy, callback) {
   Persistence.publish(scope, message, callback)
 }
 
-Status.prototype.sync = function (socket) {
-  logger.debug('#status - sync', this.to, (socket && socket.id))
+Status.prototype.sync = function (clientSession) {
+  logger.debug('#status - sync', this.to, (clientSession && clientSession.id))
 
-  this.subscribe(socket, false)
-  this.get(socket)
+  this.subscribe(clientSession, false)
+  this.get(clientSession)
 }
 
 Status.setBackend = function (backend) {

--- a/core/lib/resources/stream/subscriber_state.js
+++ b/core/lib/resources/stream/subscriber_state.js
@@ -1,5 +1,5 @@
-function StreamSubscriber (socketId) {
-  this.id = socketId
+function StreamSubscriber (clientSessionId) {
+  this.id = clientSessionId
   this.sent = null
   this.sendEnabled = true
 }
@@ -21,15 +21,15 @@ function SubscriberState () {
   this.subscribers = {}
 }
 
-SubscriberState.prototype.get = function (socketId) {
-  if (!this.subscribers[socketId]) {
-    this.subscribers[socketId] = new StreamSubscriber(socketId)
+SubscriberState.prototype.get = function (clientSessionId) {
+  if (!this.subscribers[clientSessionId]) {
+    this.subscribers[clientSessionId] = new StreamSubscriber(clientSessionId)
   }
-  return this.subscribers[socketId]
+  return this.subscribers[clientSessionId]
 }
 
-SubscriberState.prototype.remove = function (socketId) {
-  delete this.subscribers[socketId]
+SubscriberState.prototype.remove = function (clientSessionId) {
+  delete this.subscribers[clientSessionId]
 }
 
 module.exports = SubscriberState

--- a/middleware/legacy_auth_manager.js
+++ b/middleware/legacy_auth_manager.js
@@ -15,11 +15,11 @@ var logging = require('minilog')('radar:legacy_auth_manager')
 
 var LegacyAuthManager = function () {}
 
-LegacyAuthManager.prototype.onMessage = function (socket, message, messageType, next) {
-  if (!this.isAuthorized(socket, message, messageType)) {
-    logging.warn('#socket.message - unauthorized', message, socket.id)
+LegacyAuthManager.prototype.onMessage = function (clientSession, message, messageType, next) {
+  if (!this.isAuthorized(clientSession, message, messageType)) {
+    logging.warn('#clientSession.message - unauthorized', message, clientSession.id)
 
-    socket.send({
+    clientSession.send({
       op: 'err',
       value: 'auth',
       origin: message
@@ -31,12 +31,12 @@ LegacyAuthManager.prototype.onMessage = function (socket, message, messageType, 
   }
 }
 
-LegacyAuthManager.prototype.isAuthorized = function (socket, message, messageType) {
+LegacyAuthManager.prototype.isAuthorized = function (clientSession, message, messageType) {
   var isAuthorized = true
   var provider = messageType && messageType.authProvider
 
   if (provider && provider.authorize) {
-    isAuthorized = provider.authorize(messageType, message, socket)
+    isAuthorized = provider.authorize(messageType, message, clientSession)
   }
 
   return isAuthorized

--- a/middleware/legacy_auth_manager.js
+++ b/middleware/legacy_auth_manager.js
@@ -18,7 +18,7 @@ var LegacyAuthManager = function () {}
 LegacyAuthManager.prototype.onMessage = function (clientSession, message, messageType, next) {
   if (!this.isAuthorized(clientSession, message, messageType)) {
     logging.warn('#clientSession.message - unauthorized', message, clientSession.id)
-
+    console.log('auth', clientSession.constructor.name)
     clientSession.send({
       op: 'err',
       value: 'auth',

--- a/middleware/quota_manager.js
+++ b/middleware/quota_manager.js
@@ -1,6 +1,6 @@
 var MiniEventEmitter = require('miniee')
 var QuotaLimiter = require('./quota_limiter.js')
-var Client = require('../client/client.js')
+var ClientSession = require('../client/client_session.js')
 var logging = require('minilog')('radar:quota_manager')
 
 var QuotaManager = function () {
@@ -29,8 +29,8 @@ QuotaManager.prototype.checkLimits = function (socket, message, messageType, nex
     // Log Soft Limit, if available
     softLimit = this._getSoftLimit(messageType)
     if (softLimit && limiter.count(socket.id) === softLimit) {
-      var client = Client.get(socket.id)
-      this._logLimits(client, softLimit, limiter.count(socket.id))
+      var clientSession = ClientSession.get(socket.id)
+      this._logLimits(clientSession, softLimit, limiter.count(socket.id))
     }
 
     next()

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "async": "^1.5.0",
     "callback_tracker": "0.1.0",
     "engine.io": "1.4.2",
+    "javascript-state-machine": "^2.3.5",
     "lodash.bind": "^3.1.0",
     "miniee": "0.0.5",
     "minilog": "2.0.8",
@@ -47,7 +48,9 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
+    "chai-interface": "^2.0.2",
     "mocha": "^2.3.3",
+    "proxyquire": "^1.7.3",
     "radar_client": "^0.14.6",
     "simple_sentinel": "^0.1.8",
     "sinon": "^1.17.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "async": "^1.5.0",
     "callback_tracker": "0.1.0",
     "engine.io": "1.4.2",
+    "lodash.bind": "^3.1.0",
     "miniee": "0.0.5",
     "minilog": "2.0.8",
     "nomnom": "^1.8.1",
@@ -73,6 +74,8 @@
     "test-debug": "./node_modules/.bin/mocha debug --ui exports --reporter spec --slow 4000ms --bail \"$TEST\""
   },
   "standard": {
-    "ignore": ["sample/"]
+    "ignore": [
+      "sample/"
+    ]
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -7,7 +7,7 @@ var logging = require('minilog')('radar:server')
 var hostname = require('os').hostname()
 var DefaultEngineIO = require('engine.io')
 var Semver = require('semver')
-var Client = require('../client/client.js')
+var ClientSession = require('../client/client_session.js')
 var Middleware = require('../middleware')
 var Stamper = require('../core/stamper.js')
 
@@ -235,11 +235,11 @@ Server.prototype._processMessage = function (socket, message) {
 
 // Initialize a client, and persist messages where required
 Server.prototype._persistClientData = function (socket, message) {
-  var client = Client.get(socket.id)
+  var clientSession = ClientSession.get(socket.id)
 
-  if (client && Semver.gte(client.version, VERSION_CLIENT_STOREDATA)) {
+  if (clientSession && Semver.gte(clientSession.version, VERSION_CLIENT_STOREDATA)) {
     logging.info('#socket.message - _persistClientData', message, socket.id)
-    client.storeData(message)
+    clientSession.storeData(message)
   }
 }
 
@@ -330,7 +330,7 @@ Server.prototype._sendErrorMessage = function (socket, value, origin) {
 // Initialize the current client
 Server.prototype._initClient = function (socket, message) {
   // creates the mapping on nameSync
-  Client.create(message)
+  ClientSession.create(message)
 }
 
 Server.prototype._stampMessage = function (socket, message) {

--- a/server/server.js
+++ b/server/server.js
@@ -123,10 +123,11 @@ Server.prototype._setupSentry = function (configuration) {
 
 Server.prototype._onSocketConnection = function (socket) {
   var self = this
-  var oldSend = socket.send
 
-  // Always send data as json
+  // wrap socket.send
+  var oldSend = socket.send
   socket.send = function (message) {
+    // Always send data as json
     var data = JSON.stringify(message)
 
     logging.info('#socket.message.outgoing', socket.id, data)
@@ -236,7 +237,6 @@ Server.prototype._processMessage = function (socket, message) {
 // Initialize a client, and persist messages where required
 Server.prototype._persistClientData = function (socket, message) {
   var clientSession = ClientSession.get(socket.id)
-
   if (clientSession && Semver.gte(clientSession.version, VERSION_CLIENT_STOREDATA)) {
     logging.info('#socket.message - _persistClientData', message, socket.id)
     clientSession.storeData(message)

--- a/tests/client.presence.test.js
+++ b/tests/client.presence.test.js
@@ -515,7 +515,7 @@ describe('given two clients and a presence resource', function () {
     client.presence('test').on(p.notify).subscribe(function () {
       client2.presence('test').set('online')
       setTimeout(function () {
-        // Hack a bit so that socketId is saved
+        // Hack a bit so that clientSessionId is saved
         var clientId = client2.currentClientId()
         client2.currentClientId = function () { return clientId }
         // Disconnect, causing a request timeout or socket close
@@ -541,7 +541,7 @@ describe('given two clients and a presence resource', function () {
         ['online', 'client_online']
       )
 
-      // Hack a bit so that socketId is saved
+      // Hack a bit so that clientSessionId is saved
       var clientId = client.currentClientId()
       client.currentClientId = function () { return clientId }
 

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -1,16 +1,16 @@
 /* globals describe, it, beforeEach */
 var common = require('./common.js')
 var assert = require('assert')
-var Client = require('../client/client.js')
+var ClientSession = require('../client/client_session.js')
 
-describe('Client', function () {
-  var client
+describe('ClientSession', function () {
+  var clientSession
   var presences
   var subscriptions
 
   beforeEach(function (done) {
     common.startPersistence(done) // clean up
-    client = new Client('joe', Math.random(), 'test', 1)
+    clientSession = new ClientSession('joe', Math.random(), 'test', 1)
     subscriptions = {}
     presences = {}
   })
@@ -23,9 +23,9 @@ describe('Client', function () {
 
         subscriptions[to] = message
 
-        client.storeData(message)
+        clientSession.storeData(message)
 
-        client.readData(function (state) {
+        clientSession.readData(function (state) {
           assert.deepEqual(state, {
             subscriptions: subscriptions,
             presences: {}
@@ -40,9 +40,9 @@ describe('Client', function () {
 
         subscriptions[to] = message
 
-        client.storeData(message)
+        clientSession.storeData(message)
 
-        client.readData(function (state) {
+        clientSession.readData(function (state) {
           assert.deepEqual(state, {
             subscriptions: subscriptions,
             presences: {}
@@ -56,10 +56,10 @@ describe('Client', function () {
         var subscribe = { to: to, op: 'subscribe' }
         var unsubscribe = { to: to, op: 'unsubscribe' }
 
-        client.storeData(subscribe)
-        client.storeData(unsubscribe)
+        clientSession.storeData(subscribe)
+        clientSession.storeData(unsubscribe)
 
-        client.readData(function (state) {
+        clientSession.readData(function (state) {
           assert.deepEqual(state, {
             subscriptions: {},
             presences: {}
@@ -73,12 +73,12 @@ describe('Client', function () {
         var subscribe = { to: to, op: 'subscribe' }
         var sync = { to: to, op: 'sync' }
 
-        client.storeData(subscribe)
-        client.storeData(sync)
+        clientSession.storeData(subscribe)
+        clientSession.storeData(sync)
 
         subscriptions[to] = sync
 
-        client.readData(function (state) {
+        clientSession.readData(function (state) {
           assert.deepEqual(state, {
             subscriptions: subscriptions,
             presences: {}
@@ -92,12 +92,12 @@ describe('Client', function () {
         var subscribe = { to: to, op: 'subscribe' }
         var sync = { to: to, op: 'sync' }
 
-        client.storeData(sync)
-        client.storeData(subscribe)
+        clientSession.storeData(sync)
+        clientSession.storeData(subscribe)
 
         subscriptions[to] = sync
 
-        client.readData(function (state) {
+        clientSession.readData(function (state) {
           assert.deepEqual(state, {
             subscriptions: subscriptions,
             presences: {}
@@ -112,12 +112,12 @@ describe('Client', function () {
         var to = 'presence:/test/account/ticket/1'
         var message = { to: to, op: 'set', value: 'online' }
 
-        client.storeData(message)
+        clientSession.storeData(message)
 
         delete message.value
         presences[to] = message
 
-        client.readData(function (state) {
+        clientSession.readData(function (state) {
           assert.deepEqual(state, {
             subscriptions: {},
             presences: presences
@@ -131,10 +131,10 @@ describe('Client', function () {
         var online = { to: to, op: 'set', value: 'online' }
         var offline = { to: to, op: 'set', value: 'offline' }
 
-        client.storeData(online)
-        client.storeData(offline)
+        clientSession.storeData(online)
+        clientSession.storeData(offline)
 
-        client.readData(function (state) {
+        clientSession.readData(function (state) {
           assert.deepEqual(state, {
             subscriptions: {},
             presences: {}

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -4,31 +4,187 @@ var assert = require('assert')
 var ClientSession = require('../client/client_session.js')
 var EventEmitter = require('events').EventEmitter
 var sinon = require('sinon')
+var proxyquire = require('proxyquire')
 
 describe('ClientSession', function () {
   var clientSession
   var presences
   var subscriptions
-  var transport = new EventEmitter()
-  transport.send = sinon.spy()
+  var transport
 
   beforeEach(function (done) {
+    transport = new EventEmitter()
+    transport.send = sinon.spy()
     common.startPersistence(done) // clean up
     clientSession = new ClientSession('joe', Math.random(), 'test', 1, transport)
     subscriptions = {}
     presences = {}
   })
 
-  describe('message api', function () {
-    describe('incoming', function () {
-      it('emits transport message events', function (done) {
-        var originalMessage = {message: 'foo'}
-        clientSession.on('message', function (message) {
-          assert.equal(message, originalMessage)
-          done()
+  describe('.createFromSocket', function () {
+    it('instantiates a new ClientSession from a socket', function () {
+      var socket = {
+        id: 'asdf'
+      }
+      var clientSession = ClientSession.createFromSocket(socket)
+
+      assert.ok(clientSession instanceof ClientSession)
+      assert.equal(clientSession.id, socket.id)
+      assert.equal(clientSession.transport, socket)
+      assert.equal(clientSession.state.current, 'initializing')
+    })
+  })
+
+  describe('state', function () {
+    describe('_initialize', function () {
+      it('sets state to ready', function () {
+        var orig = clientSession.state.initialize
+        clientSession.state.initialize = function () {
+          clientSession.state.initialize.called = true
+          return orig.call(clientSession.state)
+        }
+
+        clientSession._initialize()
+        assert.ok(clientSession.state.initialize.called)
+        assert.equal(clientSession.state.current, 'ready')
+      })
+      it('updates lastModified', function () {
+        var clock = sinon.useFakeTimers()
+
+        try {
+          clientSession = new ClientSession()
+          assert.equal(clientSession.lastModified, 0)
+
+          clock.tick(100)
+          clientSession._initialize()
+          assert.equal(clientSession.lastModified, 100)
+        } finally {
+          clock.restore()
+        }
+      })
+      it('assigns object properties', function () {
+        clientSession._initialize({
+          name: 'abc',
+          accountName: 'qwe'
         })
 
-        transport.emit('message', originalMessage)
+        assert.equal(clientSession.name, 'abc')
+        assert.equal(clientSession.accountName, 'qwe')
+        assert.equal(clientSession.state.current, 'ready')
+      })
+    })
+    describe('_initializeOnNameSync', function () {
+      it('is called on transport message', function () {
+        clientSession._initializeOnNameSync = sinon.spy()
+        transport.emit('message', JSON.stringify({op: 'nameSync'}))
+        assert.ok(clientSession._initializeOnNameSync.called)
+      })
+      it('returns undefined when message op is not nameSync', function () {
+        assert.equal(clientSession._initializeOnNameSync({op: 'foo'}), undefined)
+      })
+      it('proxies to _initialize', function () {
+        clientSession._initialize = sinon.spy()
+
+        transport.emit('message', JSON.stringify({
+          op: 'nameSync',
+          options: {
+            association: {name: 'name'},
+            clientVersion: 2.5
+          },
+          accountName: 'accountName'
+        }))
+
+        assert.ok(clientSession._initialize.calledWith({
+          name: 'name',
+          accountName: 'accountName',
+          clientVersion: 2.5
+        }))
+      })
+    })
+    describe('end', function () {
+      it('called when the underlying socket is closed', function () {
+        var orig = clientSession.state.end
+        clientSession.state.end = function () {
+          clientSession.state.end.called = true
+          return orig.call(clientSession.state)
+        }
+
+        clientSession.state.current = 'ready'
+
+        transport.emit('close')
+
+        assert.ok(clientSession.state.end.called)
+      })
+
+      it('emits end event on end', function (done) {
+        clientSession.on('end', function () {
+          done()
+        })
+        clientSession.state.current = 'ready'
+        clientSession.state.end()
+      })
+    })
+  })
+
+  describe('message api', function () {
+    describe('incoming', function () {
+      it('emits transport message events if in ready state', function (done) {
+        var originalMessage = {message: 'foo', op: 'blah'}
+        clientSession.on('message', function (message) {
+          done()
+        })
+        clientSession.state.current = 'ready'
+        transport.emit('message', JSON.stringify(originalMessage))
+      })
+
+      it('parses JSON to object', function (done) {
+        var originalMessage = {message: 'foo', op: 'blah'}
+        clientSession.on('message', function (message) {
+          assert.deepEqual(message, originalMessage)
+          done()
+        })
+        clientSession.state.current = 'ready'
+        transport.emit('message', JSON.stringify(originalMessage))
+      })
+      it('does not emit transport message event if message is malformed', function (done) {
+        var originalMessage = {bad: true}
+        setTimeout(function () {
+          done()
+        }, 10)
+        clientSession.on('message', function (message) {
+          assert.fail('message should not be called')
+        })
+
+        transport.emit('message', JSON.stringify(originalMessage))
+      })
+      it('dispatches namesync', function () {
+        var message = {op: 'nameSync', options: {association: {id: 1, name: 'one'}}}
+        assert.equal(clientSession.state.current, 'initializing')
+        var called = 0
+        var orig = clientSession._initializeOnNameSync
+        clientSession._initializeOnNameSync = function () {
+          called++
+          orig.apply(this, arguments)
+        }
+
+        transport.emit('message', JSON.stringify(message))
+        assert.equal(called, 1)
+      })
+      it('dispatches namesync again after already initialized (multiple nameSync messages over session lifetime)', function () {
+        var message = {op: 'nameSync', options: {association: {id: 1, name: 'one'}}}
+        assert.equal(clientSession.state.current, 'initializing')
+        var called = 0
+        var orig = clientSession._initializeOnNameSync
+        clientSession._initializeOnNameSync = function () {
+          called++
+          orig.apply(this, arguments)
+        }
+
+        transport.emit('message', JSON.stringify(message))
+        assert.equal(called, 1)
+        assert.equal(clientSession.state.current, 'ready')
+        transport.emit('message', JSON.stringify(message))
+        assert.equal(called, 2)
       })
     })
     describe('outgoing - .send', function () {
@@ -37,7 +193,31 @@ describe('ClientSession', function () {
 
         clientSession.send(originalMessage)
 
-        assert.ok(transport.send.calledWith(originalMessage))
+        assert.ok(transport.send.called)
+      })
+
+      it('JSON stringifies message', function () {
+        var originalMessage = {message: 'bar'}
+        var expectedMessage = '{"message":"bar"}'
+
+        clientSession.send(originalMessage)
+
+        assert.ok(transport.send.calledWith(expectedMessage))
+      })
+
+      it('logs outgoing message', function () {
+        function logging () { return logging }
+        logging.info = sinon.spy()
+
+        var ClientSession = proxyquire('../client/client_session.js', {
+          minilog: logging
+        })
+        var id = Math.random()
+        var clientSession = new ClientSession('joe', id, 'test', 1, transport)
+
+        clientSession.send({message: 'foo'})
+
+        assert.ok(logging.info.calledWith('#socket.message.outgoing', id, '{"message":"foo"}'))
       })
     })
   })

--- a/tests/server.auth.unit.test.js
+++ b/tests/server.auth.unit.test.js
@@ -4,7 +4,7 @@ var assert = require('assert')
 var RadarTypes = require('../core/lib/type.js')
 var controlMessage = {
   to: 'control:/dev/test',
-  op: 'nameSync',
+  op: 'ctl',
   options: {
     association: {
       id: 1,
@@ -36,11 +36,9 @@ describe('given a server', function () {
     })
 
     it('it should allow access', function (done) {
-      socket.send = function (message) {
-        assert.equal('ack', message.op)
+      radarServer._handleResourceMessage = function () {
         done()
       }
-
       radarServer._processMessage(socket, controlMessage)
     })
   })

--- a/tests/server.middleware.unit.test.js
+++ b/tests/server.middleware.unit.test.js
@@ -3,7 +3,7 @@ var common = require('./common.js')
 var assert = require('assert')
 var controlMessage = {
   to: 'control:/dev/test',
-  op: 'nameSync',
+  op: 'ctl',
   options: {
     association: {
       id: 1,
@@ -26,12 +26,10 @@ describe('given a server with filters', function () {
 
   describe('with no filters', function () {
     it('should not halt execution', function (done) {
-      socket.send = function (message) {
-        assert.equal('ack', message.op)
+      radarServer._handleResourceMessage = function () {
         done()
       }
-
-      radarServer._processMessage(socket, controlMessage)
+      radarServer._processMessage(null, controlMessage)
     })
   })
 
@@ -39,9 +37,7 @@ describe('given a server with filters', function () {
     it('if OK, it should run it and continue', function (done) {
       var called = false
 
-      // Will be called
-      socket.send = function (message) {
-        assert.equal('ack', message.op)
+      radarServer._handleResourceMessage = function () {
         assert.ok(called)
         done()
       }


### PR DESCRIPTION
References
========
- [RADAR-602](https://zendesk.atlassian.net/browse/RADAR-602)

Required
========
- [ ] :+1: from @zendesk/zendesk-radar

Risks
========
- Medium: clientSession.send now expects an objects rather than a JSON string, and clientSession.on('message', handler) now emits JSON-parsed objects. The raw engineio sockets send and emit JSON strings. Internal references have been updated; other code which was previously interacting directly with engineio sockets will have to be updated to match this new signature.
- Medium: adds client session state model. Messages won't be emitted from clientSession once it has ended.
- Low: change in how client sessions are looked up by ids. Other code which is directly accessing sockets on the engineio socketServer instance will have to be updated to instead get sessions from the ClientSession module. In the future, this should be cleaned up further.