### PR TITLE
Cleanup package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "radar",
   "description": "Realtime apps with a high level API based on engine.io",
   "version": "0.18.0",
-  "author": "Mikito Takada <mikito.takada@gmail.com>",
+  "author": "Zendesk, Inc.",
+  "license": "apache-2.0",
   "engines": {
-    "node": "0.10 - 4"
+    "node": "0.10 - 5"
   },
   "contributors": [
+    "Mikito Takada <mikito.takada@gmail.com>",
     {
       "name": "Sam Shull",
       "url": "http://github.com/samshull"
@@ -18,11 +20,16 @@
     {
       "name": "Nicolas Herment",
       "url": "https://github.com/nherment"
-    }
+    },
+    "jden <jason@denizac.org>"
   ],
-  "main": "index.js",
   "keywords": [
     "realtime",
+    "real-time",
+    "pubsub",
+    "pub-sub",
+    "socketio",
+    "server",
     "socket.io",
     "engine.io",
     "comet",


### PR DESCRIPTION
- Adds [SPDX](http://npm1k.org/) license code for apache-2.0 license
- Sets Zendesk, Inc. as the author (move mixu to contributors list)
- Adds some keywords because SEO like it's 1998

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- none