### PR TITLE
Add memory leak regression tests for ClientSessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "posttest-sentinel": "./node_modules/.bin/simple_sentinel stop",
     "test-one": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --timeout 4000ms --bail \"$TEST\"",
     "test-one-solo": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --timeout 4000ms --bail",
-    "test-debug": "./node_modules/.bin/mocha debug --ui exports --reporter spec --slow 4000ms --bail \"$TEST\""
+    "test-debug": "./node_modules/.bin/mocha debug --ui exports --reporter spec --slow 4000ms --bail \"$TEST\"",
+    "test:memory": "mocha --expose-gc tests/*.memory.test.js --ui exports --reporter spec"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Realtime apps with a high level API based on engine.io",
   "version": "0.18.0",
   "author": "Zendesk, Inc.",
-  "license": "apache-2.0",
+  "license": "Apache-2.0",
   "engines": {
     "node": "0.10 - 5"
   },
@@ -62,6 +62,7 @@
     "simple_sentinel": "^0.1.8",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
+    "smooth-progress": "^1.0.4",
     "standard": "^5.4.1"
   },
   "scripts": {

--- a/tests/server.memory.test.js
+++ b/tests/server.memory.test.js
@@ -3,7 +3,6 @@ var common = require('./common.js')
 var chai = require('chai')
 var expect = chai.expect
 var EventEmitter = require('events').EventEmitter
-var progress = require('smooth-progress')
 
 describe('given a server', function () {
   var radarServer
@@ -17,6 +16,8 @@ describe('given a server', function () {
   })
 
   if (typeof gc === 'function') {
+    var progress = require('smooth-progress')
+
     it('should not leak memory when clients connect and disconnect', function (done) {
       this.timeout(0)
       var totalConnections = 100000

--- a/tests/server.memory.test.js
+++ b/tests/server.memory.test.js
@@ -1,0 +1,106 @@
+/* globals describe, it, beforeEach, afterEach, gc */
+var common = require('./common.js')
+var chai = require('chai')
+var expect = chai.expect
+var EventEmitter = require('events').EventEmitter
+var progress = require('smooth-progress')
+
+describe('given a server', function () {
+  var radarServer
+
+  beforeEach(function (done) {
+    radarServer = common.createRadarServer(done)
+  })
+
+  afterEach(function (done) {
+    radarServer.terminate(done)
+  })
+
+  if (typeof gc === 'function') {
+    it('should not leak memory when clients connect and disconnect', function (done) {
+      this.timeout(0)
+      var totalConnections = 100000
+      var concurrentConnections = 10000
+      var thresholdBytes = 1024 * 1024
+      var sockets = []
+      var socketsHighWater = 0
+      var ended = false
+      var endedConnections = 0
+
+      // make sockets
+      var s = 0
+      function makeSocket () {
+        var socket = new EventEmitter()
+        socket.id = s++
+        return socket
+      }
+      function socketConnect () {
+        var socket = makeSocket()
+        sockets.push(socket)
+        socketsHighWater = Math.max(sockets.length, socketsHighWater)
+        radarServer._onSocketConnection(socket)
+      }
+
+      function checkEnd () {
+        if (endedConnections === totalConnections && !ended) {
+          ended = true
+          gc()
+          setTimeout(function () {
+            gc()
+            var end = process.memoryUsage().heapUsed
+            console.log('Simulated', i.toLocaleString(), 'client connections, and saw max ', socketsHighWater.toLocaleString(), 'concurrent connections')
+            var growth = end - start
+            console.log('Heap growth', growth.toLocaleString(), 'bytes')
+            expect(end - start).to.be.lessThan(thresholdBytes)
+            done()
+          }, 500)
+        }
+      }
+
+      var bar = progress({
+        tmpl: 'Simulating ' + totalConnections.toLocaleString() + ' connections... :bar :percent :eta',
+        width: 25,
+        total: totalConnections
+      })
+      bar.last = 0
+      bar.i = setInterval(function () {
+        bar.tick(endedConnections - bar.last)
+        bar.last = endedConnections
+        if (endedConnections === totalConnections) { clearInterval(bar.i) }
+      }, 100)
+
+      gc()
+      var start = process.memoryUsage().heapUsed
+      var i = 0
+      asyncWhile(function () { return i < totalConnections }, function () {
+        // limit concurrent
+        if (sockets.length >= concurrentConnections || i === totalConnections) {
+          var socket = sockets.pop()
+          socket && socket.emit('close')
+          endedConnections++
+        } else {
+          i++
+          socketConnect()
+        }
+      }, function () {
+        // close remaining open sockets
+        while (sockets.length) {
+          var socket = sockets.pop()
+          socket && socket.emit('close')
+          endedConnections++
+        }
+        checkEnd()
+      })
+    })
+  } else {
+    it('skipping memory leak test, run with node --expose-gc node flag to enable test')
+  }
+})
+
+function asyncWhile (conditionPredicate, bodyFn, callback) {
+  setImmediate(function () {
+    if (!conditionPredicate()) { return callback() }
+    bodyFn()
+    asyncWhile(conditionPredicate, bodyFn, callback)
+  })
+}


### PR DESCRIPTION
- Explicitly removes ClientSession event handlers in cleanup
- Adds memory leak regression test and `npm run test:memory` command

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- None