### PR TITLE
Implement SessionManager

### DIFF
--- a/client/client_session.js
+++ b/client/client_session.js
@@ -251,10 +251,5 @@ function getClientSessionBySocketId (id) {
   return clientsById[id]
 }
 
-function createClientSessionFromSocket (socket) {
-  return new ClientSession(undefined, socket.id, undefined, undefined, socket)
-}
-
 module.exports = ClientSession
 module.exports.get = getClientSessionBySocketId
-module.exports.createFromSocket = createClientSessionFromSocket

--- a/client/socket_client_session_adapter.js
+++ b/client/socket_client_session_adapter.js
@@ -1,0 +1,24 @@
+function SocketClientSessionAdapter (clientSessionCtor) {
+  this.ClientSession = clientSessionCtor
+}
+
+SocketClientSessionAdapter.prototype.adapt = function (socket) {
+  var clientSession = new this.ClientSession(undefined, socket.id, undefined, undefined, socket)
+  return clientSession
+}
+
+// (Any) => Boolean
+SocketClientSessionAdapter.prototype.canAdapt = function (socket) {
+  return Boolean(socket &&
+    socket.id &&
+    typeof socket.send === 'function' &&
+    isEventEmitter(socket))
+}
+
+function isEventEmitter (o) {
+  return typeof o.on === 'function' &&
+    typeof o.once === 'function' &&
+    typeof o.removeListener === 'function'
+}
+
+module.exports = SocketClientSessionAdapter

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "miniee": "0.0.5",
     "minilog": "2.0.8",
     "nomnom": "^1.8.1",
+    "observable-map": "0.0.4",
     "persistence": ">= 1.0.5",
     "radar_message": "^1.1.0",
     "semver": "^5.0.3",

--- a/server/server.js
+++ b/server/server.js
@@ -11,8 +11,13 @@ var ClientSession = require('../client/client_session.js')
 var Middleware = require('../middleware')
 var Stamper = require('../core/stamper.js')
 var ServiceInterface = require('./service_interface')
+var SessionManager = require('./session_manager')
+var SocketClientSessionAdapter = require('../client/socket_client_session_adapter')
 
 function Server () {
+  this.sessionManager = new SessionManager({
+    adapters: [new SocketClientSessionAdapter(ClientSession)]
+  })
   this.socketServer = null
   this.resources = {}
   this.subscriber = null
@@ -116,7 +121,7 @@ Server.prototype._onSocketConnection = function (socket) {
   // Event: socket connected
   logging.info('#socket - connect', socket.id)
 
-  var clientSession = ClientSession.createFromSocket(socket)
+  var clientSession = this.sessionManager.add(socket)
 
   clientSession.on('message', function (data) {
     self._processMessage(clientSession, data)

--- a/server/session_manager.js
+++ b/server/session_manager.js
@@ -1,0 +1,71 @@
+var log = require('minilog')('radar:session_manager')
+var ClientSession = require('../client/client_session')
+var EventEmitter = require('events').EventEmitter
+var inherits = require('util').inherits
+var ObservableMap = require('observable-map')
+var _ = require('underscore')
+
+function SessionManager (opt) {
+  var self = this
+  this.sessions = new ObservableMap()
+  this.sessions.on('change', function (event) {
+    self.emit('change', event)
+  })
+
+  this.adapters = opt && opt.adapters || []
+}
+inherits(SessionManager, EventEmitter)
+
+SessionManager.prototype.add = function (obj) {
+  var self = this
+  var session
+
+  if (obj instanceof ClientSession) {
+    session = obj
+  } else if (this.canAdapt(obj)) {
+    session = this.adapt(obj)
+  } else {
+    throw new TypeError('No adapter found for ' + obj)
+  }
+
+  if (this.has(session.id)) {
+    log.info('Attemping to add duplicate session id:', session.id)
+    return this
+  }
+
+  this.sessions.set(session.id, session)
+  session.once('end', function () {
+    self.sessions.delete(session.id)
+    self.emit('end', session)
+  })
+  return this
+}
+
+SessionManager.prototype.has = function (id) {
+  return this.sessions.has(id)
+}
+
+SessionManager.prototype.length = function () {
+  return this.sessions.size
+}
+
+SessionManager.prototype.get = function (id) {
+  return this.sessions.get(id)
+}
+
+// (Any) => Boolean
+SessionManager.prototype.canAdapt = function (obj) {
+  return this.adapters.some(function (adapter) {
+    return adapter.canAdapt(obj)
+  })
+}
+
+// (Any) => ClientSession?
+SessionManager.prototype.adapt = function (obj) {
+  var adapter = _.find(this.adapters, function (adapter) {
+    return adapter.canAdapt(obj)
+  })
+  return adapter && adapter.adapt(obj) || null
+}
+
+module.exports = SessionManager

--- a/tests/client.socket_client_session_adapter.test.js
+++ b/tests/client.socket_client_session_adapter.test.js
@@ -1,0 +1,85 @@
+/* globals describe, it, beforeEach */
+var SocketClientSessionAdapter = require('../client/socket_client_session_adapter')
+var ClientSession = require('../client/client_session')
+var chai = require('chai')
+chai.use(require('sinon-chai'))
+chai.use(require('chai-interface'))
+var expect = chai.expect
+var sinon = require('sinon')
+
+describe('SocketClientSessionAdapter', function () {
+  var socketClientSessionAdapter
+  beforeEach(function () {
+    socketClientSessionAdapter = new SocketClientSessionAdapter(ClientSession)
+  })
+
+  it('can be instantiated', function () {
+    expect(socketClientSessionAdapter)
+      .to.be.instanceof(SocketClientSessionAdapter)
+  })
+
+  it('has interface', function () {
+    expect(socketClientSessionAdapter).to.have.interface({
+      canAdapt: Function,
+      adapt: Function
+    })
+  })
+
+  it('takes ClientSession constructor in own constructor', function () {
+    function Foo () {}
+    socketClientSessionAdapter = new SocketClientSessionAdapter(Foo)
+    expect(socketClientSessionAdapter.ClientSession)
+      .to.equal(Foo)
+  })
+
+  describe('#canAdapt', function () {
+    describe('given a socket-like object', function () {
+      var obj = {
+        id: 5,
+        send: function () {},
+        on: function () {},
+        once: function () {},
+        removeListener: function () {}
+      }
+      it('returns true', function () {
+        expect(socketClientSessionAdapter.canAdapt(obj))
+          .to.be.true
+      })
+    })
+    describe('given non-socket-like object', function () {
+      var obj = {foo: 'bar'}
+      it('returns false', function () {
+        expect(socketClientSessionAdapter.canAdapt(obj))
+          .to.be.false
+      })
+    })
+    describe('given null', function () {
+      it('returns false', function () {
+        expect(socketClientSessionAdapter.canAdapt(null))
+          .to.be.false
+      })
+    })
+  })
+
+  describe('#adapt', function () {
+    describe('given a socket-like object', function () {
+      var socket = {
+        id: 'foo'
+      }
+      var ctor
+
+      beforeEach(function () {
+        ctor = sinon.stub()
+        socketClientSessionAdapter.ClientSession = ctor
+      })
+
+      it('news ClientSession with id and transport', function () {
+        socketClientSessionAdapter.adapt(socket)
+        expect(ctor)
+          .to.have.been.calledWith(undefined, 'foo', undefined, undefined, socket)
+        expect(ctor)
+          .to.have.been.calledWithNew
+      })
+    })
+  })
+})

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -21,20 +21,6 @@ describe('ClientSession', function () {
     presences = {}
   })
 
-  describe('.createFromSocket', function () {
-    it('instantiates a new ClientSession from a socket', function () {
-      var socket = {
-        id: 'asdf'
-      }
-      var clientSession = ClientSession.createFromSocket(socket)
-
-      assert.ok(clientSession instanceof ClientSession)
-      assert.equal(clientSession.id, socket.id)
-      assert.equal(clientSession.transport, socket)
-      assert.equal(clientSession.state.current, 'initializing')
-    })
-  })
-
   describe('state', function () {
     describe('_initialize', function () {
       it('sets state to ready', function () {

--- a/tests/server.session_manager.test.js
+++ b/tests/server.session_manager.test.js
@@ -1,0 +1,191 @@
+/* globals describe, it, beforeEach */
+var SessionManager = require('../server/session_manager')
+var ClientSession = require('../client/client_session')
+var chai = require('chai')
+chai.use(require('sinon-chai'))
+chai.use(require('chai-interface'))
+var expect = chai.expect
+var sinon = require('sinon')
+
+describe('SessionManager', function () {
+  var sessionManager
+  beforeEach(function () {
+    sessionManager = new SessionManager()
+  })
+
+  it('can be instantiated', function () {
+    expect(sessionManager).to.be.instanceof(SessionManager)
+  })
+
+  it('has interface', function () {
+    expect(sessionManager).to.have.interface({
+      sessions: Object,
+      adapters: Array,
+      on: Function,
+      once: Function,
+      add: Function,
+      has: Function,
+      length: Function,
+      get: Function
+    })
+  })
+
+  describe('client session adapters', function () {
+    it('can be instantiated with adapters', function () {
+      var adapters = [{}, {}]
+      sessionManager = new SessionManager({adapters: adapters})
+      expect(sessionManager.adapters).to.deep.equal(adapters)
+    })
+
+    describe('#canAdapt', function () {
+      var someObj = {foo: 1}
+
+      it('returns true when an adapter matches', function () {
+        var adapterStub1 = {canAdapt: sinon.stub().returns(false)}
+        var adapterStub2 = {canAdapt: sinon.stub().returns(true)}
+        sessionManager.adapters.push(adapterStub1, adapterStub2)
+        expect(sessionManager.canAdapt(someObj))
+          .to.be.true
+      })
+      it('returns false when no adapter matches', function () {
+        var adapterStub1 = {canAdapt: sinon.stub().returns(false)}
+        sessionManager.adapters.push(adapterStub1)
+        expect(sessionManager.canAdapt(someObj))
+          .to.be.false
+      })
+      it('returns false when no adapters', function () {
+        expect(sessionManager.canAdapt(someObj))
+          .to.be.false
+      })
+    })
+
+    describe('#adapt', function () {
+      var someObj = {foo: 1}
+      var adapter
+      describe('given a matching adapter', function () {
+        var session = {}
+        beforeEach(function () {
+          adapter = {
+            adapt: sinon.stub().returns(session),
+            canAdapt: sinon.stub().returns(true)
+          }
+          sessionManager.adapters.push(adapter)
+        })
+        it('applies adapter#adapt to obj', function () {
+          expect(sessionManager.adapt(someObj))
+            .to.equal(session)
+          expect(adapter.canAdapt)
+            .to.have.been.calledWith(someObj)
+          expect(adapter.adapt)
+            .to.have.been.calledWith(someObj)
+        })
+      })
+      describe('given no matching adapter', function () {
+        beforeEach(function () {
+          adapter = {
+            adapt: sinon.stub(),
+            canAdapt: sinon.stub().returns(false)
+          }
+        })
+        it('returns null', function () {
+          expect(sessionManager.adapt(someObj))
+            .to.equal(null)
+          expect(adapter.adapt)
+            .not.to.have.been.called
+        })
+      })
+    })
+  })
+
+  describe('when adding a session', function () {
+    var clientSession
+    beforeEach(function () {
+      clientSession = new ClientSession('', 'foo')
+      clientSession.once = sinon.spy()
+      sessionManager.add(clientSession)
+    })
+
+    it('exposes legth of collection', function () {
+      expect(sessionManager.length()).to.equal(1)
+    })
+
+    it('can check if has id', function () {
+      expect(sessionManager.has('foo')).to.be.true
+    })
+
+    it('can get by id', function () {
+      expect(sessionManager.get('foo'))
+        .to.equal(clientSession)
+    })
+
+    it('adding same session multiple times has no effect', function () {
+      sessionManager.add(clientSession)
+      sessionManager.add(clientSession)
+      expect(sessionManager.length()).to.equal(1)
+      expect(clientSession.once).to.have.callCount(1)
+    })
+
+    describe('given a ClientSession', function () {
+      var clientSession = new ClientSession('', 2)
+
+      it('can be added', function () {
+        sessionManager.add(clientSession)
+        expect(sessionManager.has(2))
+          .to.be.true
+      })
+    })
+
+    describe('given a non-ClientSession', function () {
+      var someObj = {id: 'one'}
+
+      it('tries to adapt the obj', function () {
+        var adapter = {
+          canAdapt: sinon.stub().returns(true),
+          adapt: sinon.stub().returns(new ClientSession())
+        }
+        sessionManager.adapters.push(adapter)
+
+        try {
+          sessionManager.add(someObj)
+        } finally {
+          expect(adapter.adapt).to.have.been.calledWith(someObj)
+        }
+      })
+
+      describe('when can be adapted', function () {
+        var adapted = new ClientSession('', 1)
+        var adapter
+
+        beforeEach(function () {
+          adapter = {
+            canAdapt: sinon.stub().returns(true),
+            adapt: sinon.stub().returns(adapted)
+          }
+          sessionManager.adapters.push(adapter)
+        })
+
+        it('adds the adapted ClientSession', function () {
+          sessionManager.add(someObj)
+          expect(sessionManager.has(1))
+            .to.be.true
+        })
+      })
+      describe('when cannot be adapted', function () {
+        var adapter
+
+        beforeEach(function () {
+          adapter = {
+            canAdapt: sinon.stub().returns(false)
+          }
+          sessionManager.adapters.push(adapter)
+        })
+
+        it('throws', function () {
+          expect(function () {
+            sessionManager.add(someObj)
+          }).to.throw(TypeError, /adapter/)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR creates a class called SessionManager that wraps [ObservableMap](http://npm.im/observable-map).
The SessionManager is responsible for instantiating and tracking all active ClientSessions.
The underlying ObservableMap indexes ClientSessions by id, and emits 'change' events when sessions are
added or deleted. SessionManager also emits an 'end'  event when ClientSessions end.

The design of this class is to enable:
- easy instrumentation for monitoring
- a single point in the RadarServer to store of all ClientSessions
- a single event emitter to handle all ClientSessions the same (e.g., for cleaning up Resources, etc)
- isolate knowledge of how to instantiate ClientSessions from various underlying transports (Engine.io, ServiceInterface)
  via the Adapter pattern

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- Low: adds third party dependency on http://npm.im/observable-map