### PR TITLE
Release 0.19.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+### 0.19.0
+* [PR #203](https://github.com/zendesk/radar/pull/203) - HTTP ServiceInterface
+* [PR #202](https://github.com/zendesk/radar/pull/202) - Add memory leak regression tests for ClientSessions
+* [PR #200](https://github.com/zendesk/radar/pull/200) - Cleanup package.json
+* [PR #201](https://github.com/zendesk/radar/pull/201) - Spruce up the readme a bit
+
 ### 0.18.0
 Switched to http://standardjs.com/ style
 * #195, #197 - format for standard

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "radar",
   "description": "Realtime apps with a high level API based on engine.io",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "author": "Zendesk, Inc.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Includes
* [PR #203](https://github.com/zendesk/radar/pull/203) - HTTP ServiceInterface
* [PR #202](https://github.com/zendesk/radar/pull/202) - Add memory leak regression tests for ClientSessions
* [PR #200](https://github.com/zendesk/radar/pull/200) - Cleanup package.json
* [PR #201](https://github.com/zendesk/radar/pull/201) - Spruce up the readme a bit

Releasing and publishing to npm

merging without +1 because no code change