### PR TITLE
Add npm version badge to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 The real-time service layer for your web application
 
+[![npm](https://img.shields.io/npm/v/radar.svg)](https://www.npmjs.com/package/radar)
 [![Build Status](https://travis-ci.org/zendesk/radar.svg?branch=master)](https://travis-ci.org/zendesk/radar)
 [![Dependency Status](https://david-dm.org/zendesk/radar.svg)](https://david-dm.org/zendesk/radar)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)


### PR DESCRIPTION
Shows most recent published npm version number in readme. It's currently orange
because we're < v1.0.0, and semver's guarantees are weaker below MAJOR=1.

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- none
