### PR TITLE
Server: Emit resource:destroy event

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -42,6 +42,7 @@ Server.prototype.destroyResource = function (to) {
       if (err) { throw err }
 
       resource.destroy()
+      self.emit('resource:destroy', resource)
       delete self.resources[to]
       delete self.subs[to]
 

--- a/tests/server.unit.test.js
+++ b/tests/server.unit.test.js
@@ -55,6 +55,23 @@ describe('given a server', function () {
     }, 100)
   })
 
+  it('should emit resource:destroy when a resource is destroyed', function (done) {
+    var stubResource = {
+      destroy: function () {}
+    }
+
+    radarServer.on('resource:destroy', function (resource) {
+      expect(resource).to.equal(stubResource)
+      done()
+    })
+
+    radarServer.resources = {
+      'status:/test/foo': stubResource
+    }
+
+    radarServer.destroyResource('status:/test/foo')
+  })
+
   it('should return an error when an invalid message type is sent', function (done) {
     var invalidMessage = {
       to: 'invalid:/thing'


### PR DESCRIPTION
For symmetry with the `resource:new` event that we currently emit, and to enable unobtrusive instrumentation.

## Required
- [ ] :+1: from @zendesk/radar 

## Risks
- None
