### PR TITLE
Remove Presence.Sentry refernce to Sentry module #major_version

### DIFF
--- a/core/lib/resources/presence/index.js
+++ b/core/lib/resources/presence/index.js
@@ -15,7 +15,6 @@ var default_options = {
   }
 }
 
-Presence.Sentry = Sentry
 Presence.sentry = new Sentry()
 
 function Presence (to, server, options) {

--- a/server/server.js
+++ b/server/server.js
@@ -179,11 +179,6 @@ Server.prototype._handlePubSubMessage = function (to, data) {
     logging.info('#redis.message.incoming', to, data)
     this.resources[to].redisIn(data)
   } else {
-    // Don't log sentry channel pub messages
-    if (to === Core.Presence.Sentry.channel) {
-      return
-    }
-
     logging.warn('#redis - message not handled', to, data)
   }
 }


### PR DESCRIPTION
Removes reference to Sentry module as Presence.Sentry. It should be driectly
required instead.

(Note: staging this as a PR, but I don't intend to land this until the rest of the 1.0 milestone)

Required
========
- [ ] Major version bump, breaking public API change
- [ ] :+1: from @zendesk/radar

Risks
========
- None