### PR TITLE
Log when missing transport on ClientSession.prototype.send

### DIFF
--- a/client/client_session.js
+++ b/client/client_session.js
@@ -61,7 +61,11 @@ ClientSession.prototype._cleanup = function () {
 ClientSession.prototype.send = function (message) {
   var data = JSON.stringify(message)
   log.info('#socket.message.outgoing', this.id, data)
-  this.transport.send(data)
+  if (!this.transport || !this.transport.send) {
+    log.warn('Missing transport, skipping message send', this.id, this.accountName, this.name)
+  } else {
+    this.transport.send(data)
+  }
 }
 
 // Persist subscriptions and presences when not already persisted in memory


### PR DESCRIPTION
Some ClientSessions appear not to have an underlying transport.send. This
adds some logging to troubleshoot further.

References
========
- [RADAR-647](https://zendesk.atlassian.net/browse/RADAR-647)

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- Medium, some messages will not be sent (note that this is currently happening and crashing the process with an uncaught exception)