### PR TITLE
Skip message on ClientSession#send if ClientSession is ended

### DIFF
--- a/client/client_session.js
+++ b/client/client_session.js
@@ -61,11 +61,12 @@ ClientSession.prototype._cleanup = function () {
 ClientSession.prototype.send = function (message) {
   var data = JSON.stringify(message)
   log.info('#socket.message.outgoing', this.id, data)
-  if (!this.transport || !this.transport.send) {
-    log.warn('Missing transport, skipping message send', this.id, this.accountName, this.name)
-  } else {
-    this.transport.send(data)
+  if (this.state.current === 'ended') {
+    log.warn('Cannot send message after ClientSession ended', this.id, data)
+    return
   }
+
+  this.transport.send(data)
 }
 
 // Persist subscriptions and presences when not already persisted in memory

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -182,6 +182,14 @@ describe('ClientSession', function () {
         assert.ok(transport.send.called)
       })
 
+      it('skips sending message if state is ended', function () {
+        clientSession.state.end()
+
+        clientSession.send({})
+
+        assert.ok(!transport.send.called)
+      })
+
       it('JSON stringifies message', function () {
         var originalMessage = {message: 'bar'}
         var expectedMessage = '{"message":"bar"}'


### PR DESCRIPTION
More permanent fix for #217. Sometimes a ClientSession will end in
the middle of a resource operation, like get. Once the async resource
operation is complete, it will attempt to send a response message
to the client. If the client is already ended, ClientSession.send should
be a no-op. This PR logs a warning for the undelivered message.

References
========
- [RADAR-647](https://zendesk.atlassian.net/browse/RADAR-647)
- #217

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- None.