### PR TITLE
Disable eslint in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,6 @@
 engines:
   eslint:
-    enabled: true
+    enabled: false
 exclude_paths:
 - "sample/*"
 ratings:


### PR DESCRIPTION
We use [standard](http://standardjs.com/) rather than eslint.
Currently we run it in a pretest step, so linting errors would be caught in a travisci build failure.
In the future, we may be able to move this linting step back into codeclimate.

References
========
- [Pending `standard` codeclimate engine](https://github.com/feross/standard/issues/342)

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- None, we lint using [standard](http://standardjs.com/) in our pretest npm script.