### PR TITLE
Forward sentry events on server

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -169,11 +169,15 @@ Server.prototype._setupSentry = function (configuration) {
     _.extend(sentryOptions, configuration.sentry)
   }
 
-  var sentry = new Sentry()
-  this.sentry = sentry
+  this.sentry = new Sentry()
   this.sentry.start(sentryOptions)
 
-  sentry.on('down', function (sentryId) {
+  this.sentry.on('up', function (sentryId, message) {
+    self.emit('sentry:up', sentryId, message)
+  })
+
+  this.sentry.on('down', function (sentryId, message) {
+    self.emit('sentry:down', sentryId, message)
     self._onSentryDown(sentryId)
   })
 }

--- a/tests/server.unit.test.js
+++ b/tests/server.unit.test.js
@@ -217,6 +217,27 @@ describe('given a server', function () {
       expect(listenerCount(sentry, 'down')).to.equal(1)
     })
 
+    it('forwards sentry on down event', function (done) {
+      var sentry = radarServer.sentry
+
+      radarServer.on('sentry:down', function (sentryId, message) {
+        expect(sentryId).to.equal('sentryId')
+        expect(message).to.deep.equal({message: true})
+        done()
+      })
+      sentry.emit('down', 'sentryId', {message: true})
+    })
+    it('forwards sentry on up event', function (done) {
+      var sentry = radarServer.sentry
+
+      radarServer.on('sentry:up', function (sentryId, message) {
+        expect(sentryId).to.equal('sentryId')
+        expect(message).to.deep.equal({message: true})
+        done()
+      })
+      sentry.emit('up', 'sentryId', {message: true})
+    })
+
     describe('#_onSentryDown', function () {
       var stubStore
       beforeEach(function () {


### PR DESCRIPTION
Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- Low, introduces informal event api to server