### PR TITLE
Return Server#ready promise from Server#attach

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -31,7 +31,6 @@ function Server () {
   this.subs = {}
   this.sentry = null
 
-  this._ready
   this.ready = new Promise(function (resolve) {
     self._ready = resolve
   })
@@ -45,6 +44,7 @@ Middleware.Runner.mixin(Server)
 // Attach to a http server
 Server.prototype.attach = function (httpServer, configuration) {
   this._setup(httpServer, configuration)
+  return this.ready
 }
 
 // Destroy empty resource

--- a/tests/server.unit.test.js
+++ b/tests/server.unit.test.js
@@ -219,6 +219,16 @@ describe('given a server', function () {
       var returned = radarServer.attach(httpServer, common.configuration)
       expect(returned).to.equal(radarServer.ready)
     })
+
+    it('ready promise resolves once server is setup', function () {
+      var httpServer = require('http').createServer(function () {})
+      var radarServer = new Server()
+      radarServer._stup = sinon.spy(radarServer, '_setup')
+      return radarServer.attach(httpServer, common.configuration)
+        .then(function () {
+          expect(radarServer._setup).to.have.been.called
+        })
+    })
   })
 
   describe('Sentry setup', function () {

--- a/tests/server.unit.test.js
+++ b/tests/server.unit.test.js
@@ -3,6 +3,7 @@ var common = require('./common.js')
 var assert = require('assert')
 var sinon = require('sinon')
 var chai = require('chai')
+var Server = require('../server/server')
 var expect = chai.expect
 var subscribeMessage = {
   op: 'subscribe',
@@ -207,6 +208,16 @@ describe('given a server', function () {
           done()
         }, 30)
       })
+    })
+  })
+
+  describe('#attach', function () {
+    it('returns ready promise', function () {
+      var httpServer = require('http').createServer(function () {})
+      var radarServer = new Server()
+
+      var returned = radarServer.attach(httpServer, common.configuration)
+      expect(returned).to.equal(radarServer.ready)
     })
   })
 


### PR DESCRIPTION
Return the server ready promise from the Server.attach method

Required
========
- [x] :+1: from @zendesk/radar

Risks
========
- None (was not returning a value)