### PR TITLE
Don't delete presence_store when disposing presence resource

### DIFF
--- a/src/core/resources/presence/index.js
+++ b/src/core/resources/presence/index.js
@@ -234,6 +234,7 @@ Presence.prototype.fullRead = function (callback) {
 
 Presence.prototype.destroy = function () {
   this.manager.destroy()
+  Resource.prototype.destroy.call(this)
 }
 
 Presence.setBackend = function (backend) {

--- a/src/core/resources/presence/presence_manager.js
+++ b/src/core/resources/presence/presence_manager.js
@@ -61,8 +61,6 @@ PresenceManager.prototype.destroy = function () {
   if (this.handleRedisReply) {
     this.handleRedisReply = function () {}
   }
-
-  delete this.store
 }
 // FIXME: Method signature is getting unmanageable
 PresenceManager.prototype.addClient = function (clientSessionId, userId, userType,

--- a/src/core/resources/resource.js
+++ b/src/core/resources/resource.js
@@ -135,7 +135,9 @@ Resource.prototype.handleMessage = function (clientSession, message) {
   }
 }
 
-Resource.prototype.destroy = function () {}
+Resource.prototype.destroy = function () {
+  this.destroyed = true
+}
 
 Resource.setBackend = function (backend) {
   // noop

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -197,6 +197,10 @@ Server.prototype._onSentryDown = function (sentryId) {
   var started = Date.now()
 
   nonblocking(presences).forEach(function (presence) {
+    if (presence.destroyed) {
+      return
+    }
+
     var clientSessionIds = presence.manager.store.clientSessionIdsForSentryId(sentryId)
     expected += clientSessionIds.length
 

--- a/test/presence.unit.test.js
+++ b/test/presence.unit.test.js
@@ -5,6 +5,7 @@ var Persistence = require('persistence')
 var Common = require('./common.js')
 var Presence = require('../src/core/resources/presence')
 var sinon = require('sinon')
+var expect = require('chai').expect
 
 describe('given a presence resource', function () {
   var presence, client, client2
@@ -533,6 +534,14 @@ describe('given a presence resource', function () {
 
       presence.set(client, { type: 2, key: 123, value: 'online', userData: { test: 1 } })
       presence.get(fakeClient, { options: { version: 2 } })
+    })
+  })
+
+  describe('#destroy()', function () {
+    it('sets resource.destroyed flag to true', function () {
+      expect(!presence.destroyed).to.equal(true)
+      presence.destroy()
+      expect(presence.destroyed).to.equal(true)
     })
   })
 })

--- a/test/server.unit.test.js
+++ b/test/server.unit.test.js
@@ -286,6 +286,16 @@ describe('given a server', function () {
         })
       })
 
+      it('ignores presences that are destroyed during processing', function (done) {
+        radarServer._onSentryDown('sentry1')
+        radarServer.resources[234].destroyed = true
+        radarServer.on('profiling', function () {
+          expect(radarServer.resources[123].manager.disconnectRemoteClient).to.have.been.calledTwice
+          expect(radarServer.resources[234].manager.disconnectRemoteClient).not.to.have.been.called
+          done()
+        })
+      })
+
       it('emits profiling event', function (done) {
         radarServer._onSentryDown('sentry1')
         radarServer.on('profiling', function (e) {


### PR DESCRIPTION
I can't think of a good reason why we ever should have been manually `delete`ing the Store in `PresenceManager#destroy` in the first place, and 35k and change good reasons why we shouldn't have been.

This PR fixes this, and adds a test to ensure that anything which had an indirect reference to the user store at time T will still have that reference at time T', even if the Presence resource has been `destroy`ed in between.

Once that reference is released normally, the PresenceStore will be available for regular garbage collection.

References
========
- [RADAR-651](https://zendesk.atlassian.net/browse/RADAR-651)

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- None.