### PR TITLE
Add bin/server.js to package.json bin

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,6 +1,7 @@
+#!/usr/bin/env node
 var http = require('http')
 var configuration = require('../configurator.js').load({persistence: true})
-var Radar = require('../server/server.js')
+var Radar = require('../src/server/server.js')
 var Api = require('../api/api.js')
 var Minilog = require('minilog')
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "comet",
     "ajax"
   ],
+  "bin": "./bin/server.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/zendesk/radar.git"


### PR DESCRIPTION
Adds bin/server.js to package.json so npm will create executable when `npm install radar`.
Makes it easier to consume radar from shell scripts, eg

```console
npm install radar && radar --port 9999
```
Also fixes relative path for good measure (broke in https://github.com/zendesk/radar/pull/225)

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- None