### PR TITLE
Initialize Sentry id with Server id

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -169,7 +169,7 @@ Server.prototype._setupSentry = function (configuration) {
     _.extend(sentryOptions, configuration.sentry)
   }
 
-  this.sentry = new Sentry()
+  this.sentry = new Sentry(this.id)
   this.sentry.start(sentryOptions)
 
   this.sentry.on('up', function (sentryId, message) {

--- a/test/server.unit.test.js
+++ b/test/server.unit.test.js
@@ -238,6 +238,10 @@ describe('given a server', function () {
       expect(listenerCount(sentry, 'down')).to.equal(1)
     })
 
+    it('uses Server.id as sentry name', function () {
+      expect(radarServer.sentry.name).to.equal(radarServer.id)
+    })
+
     it('forwards sentry on down event', function (done) {
       var sentry = radarServer.sentry
 


### PR DESCRIPTION
The server is initialized before the sentry, and we need a way to uniquely identify
the server for its entire lifetime. The sentry is 1:1 with the server, so initialize
it with the server's id.

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- None