### PR TITLE
Allow extensions to process control messages

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -156,6 +156,8 @@ Server.prototype._setupDistributor = function () {
     logging.info('#redis.message.outgoing', channel, data)
     oldPublish(channel, data, callback)
   }
+
+  this.publish = Redis.publish
 }
 
 Server.prototype._setupSentry = function (configuration) {

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -325,6 +325,9 @@ Server.prototype._persistClientData = function (socket, message) {
 // Get a resource, subscribe where required, and handle associated message
 Server.prototype._handleResourceMessage = function (socket, message, messageType) {
   var self = this
+  if (messageType.type === 'Control') {
+    return
+  }
   var to = message.to
   var resource = this._getResource(message, messageType)
 

--- a/test/server.unit.test.js
+++ b/test/server.unit.test.js
@@ -231,6 +231,14 @@ describe('given a server', function () {
     })
   })
 
+  describe('Distributor setup', function () {
+    it('exposes publish function', function () {
+      var radarServer = new Server()
+      radarServer._setupDistributor()
+      expect(radarServer.publish).to.be.a('function')
+    })
+  })
+
   describe('Sentry setup', function () {
     it('registers sentry on down handler', function () {
       var sentry = radarServer.sentry

--- a/test/server.unit.test.js
+++ b/test/server.unit.test.js
@@ -211,6 +211,18 @@ describe('given a server', function () {
     })
   })
 
+  describe('#_handleResourceMessage', function () {
+    it('skips control messages', function () {
+      var radarServer = new Server()
+      var typeDefinition = {
+        type: 'Control'
+      }
+      radarServer._getResource = sinon.spy()
+      radarServer._handleResourceMessage({}, {}, typeDefinition)
+      expect(radarServer._getResource).not.to.have.been.called
+    })
+  })
+
   describe('#attach', function () {
     it('returns ready promise', function () {
       var httpServer = require('http').createServer(function () {})


### PR DESCRIPTION
This PR:
- exposes the publish function for the redis pubsub connection
- bypasses control messages for the default RadarServer._handleResourceMessage handler

Allowing programmatic users of RadarServer to process control messages from the same
sources (ServiceInterface, engineio) as other message types.


Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- Low: no default handler is specified for control messages