### PR TITLE
Allow charset in ServiceInterface content-type

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "async": "^1.5.0",
     "callback_tracker": "0.1.0",
     "concat-stream": "^1.5.1",
+    "content-type": "^1.0.2",
     "engine.io": "1.4.2",
     "http-attach": "^1.0.0",
     "javascript-state-machine": "^2.3.5",

--- a/src/server/service_interface.js
+++ b/src/server/service_interface.js
@@ -6,6 +6,7 @@ var parseUrl = require('url').parse
 var RadarMessage = require('radar_message')
 var concatStream = require('concat-stream')
 var id = require('../core/id')
+var parseContentType = require('content-type').parse
 
 function ServiceInterface (middlewareRunner) {
   this._middlewareRunner = middlewareRunner || noopMiddlewareRunner
@@ -91,7 +92,14 @@ function error (err, res) {
 
 ServiceInterface.prototype._post = function (req, res) {
   var self = this
-  if (!req.headers || req.headers['content-type'] !== 'application/json') {
+
+  try {
+    var contentType = parseContentType(req.headers['content-type']).type
+  } catch (e) {
+    log.info('Parsing content-type failed', req.headers['content-type'])
+  }
+
+  if (!req.headers || contentType !== 'application/json') {
     var err = new Error('Content-type must be application/json')
     err.statusCode = 415
     return error(err, res)

--- a/test/service_interface.test.js
+++ b/test/service_interface.test.js
@@ -110,6 +110,27 @@ describe('ServiceInterface', function () {
       })
       serviceInterface.middleware(req, res)
     })
+
+    it('allows content-type with charset', function (done) {
+      var req = postReq({
+        op: 'get',
+        to: 'status:/test/result',
+        key: 'abc'
+      })
+
+      req.headers['content-type'] = 'application/json;charset=UTF-8'
+      var res = stubRes({
+        end: function () {
+          expect(res.statusCode).to.equal(200)
+          done()
+        }
+      })
+      serviceInterface.on('request', function (clientSession, message) {
+        clientSession.send({status: 'ok'})
+      })
+      serviceInterface.middleware(req, res)
+    })
+
     it('requires valid json in body', function (done) {
       var req = literalStream('some non-json garbage')
       req.method = 'POST'


### PR DESCRIPTION
> if we send the `Content-type` as `application/json;charset=UTF-8` Radar is rejecting the request saying that the content-type must be `application/json`

> problem: libraries like `Dispatch`, in Scala, suggest us to set a charset in this header. Being the charset part of this header, shouldn't it be accepted?

This PR allows ServiceInterface requests to optionally include a charset in their Content-Type. Radar expects all requests to be UTF-8 whether or not
a charset is specified.

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- None