### PR TITLE
Lower "type not found" log level from error -> warn

### DIFF
--- a/src/core/type.js
+++ b/src/core/type.js
@@ -47,7 +47,7 @@ function getByExpression (to) {
       }
     }
   }
-  logger.error('#type - Unable to find a valid type definition for:', to)
+  logger.warn('#type - Unable to find a valid type definition for:' + to)
 }
 
 module.exports = {


### PR DESCRIPTION
When a message refers to a resource that doesn't match any of the defined resource scope types, it's a client error, but the server can handle it just fine. We should still log it, since it might help investigating a client problem, but it is not a server error. This PR reduces log noise.

Also reformats message as string rather than additional param for better message

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- None