### PR TITLE
Api status set: unsubscribe if list of subscribers is empty

### DIFF
--- a/src/core/resources/resource.js
+++ b/src/core/resources/resource.js
@@ -96,7 +96,7 @@ Resource.prototype.redisIn = function (data) {
 
   this.emit('message:outgoing', data)
 
-  if (!Object.keys(this.subscribers).length) {
+  if (Object.keys(this.subscribers).length === 0) {
     logging.info('#' + this.type, '- no subscribers, destroying resource', this.to)
     this.server.destroyResource(this.to)
   }

--- a/src/core/resources/resource.js
+++ b/src/core/resources/resource.js
@@ -95,6 +95,11 @@ Resource.prototype.redisIn = function (data) {
   })
 
   this.emit('message:outgoing', data)
+
+  if (!Object.keys(this.subscribers).length) {
+    logging.info('#' + this.type, '- no subscribers, destroying resource', this.to)
+    this.server.destroyResource(this.to)
+  }
 }
 
 // Return a socket reference; eio server hash is "clients", not "sockets"

--- a/test/status.unit.test.js
+++ b/test/status.unit.test.js
@@ -218,5 +218,38 @@ describe('a status resource', function () {
         radarServer._processMessage(socketTwo, setMessage)
       }, 100)
     })
+
+    // Case when setting status with the api
+    describe('when not subscribed', function () {
+      it('should emit outgoing messages', function (done) {
+        var setMessage = {op: 'set', to: 'status:/z1/test/ticket/1', value: {1: 2}}
+        var socketOne = {id: 1, send: function (m) {}}
+
+        radarServer.on('resource:new', function (resource) {
+          resource.on('message:outgoing', function (message) {
+            done()
+          })
+        })
+
+        setTimeout(function () {
+          radarServer._processMessage(socketOne, setMessage)
+        }, 100)
+      })
+
+      it('should unsubcribe (destroy resource) if there are no subscribers', function (done) {
+        var to = 'status:/z1/test/ticket/1'
+        var setMessage = {op: 'set', to: to, value: {1: 2}}
+        var socketOne = {id: 1, send: function (m) {}}
+
+        radarServer.on('resource:destroy', function (resource) {
+          assert.equal(radarServer.resources[to], resource)
+          done()
+        })
+
+        setTimeout(function () {
+          radarServer._processMessage(socketOne, setMessage)
+        }, 100)
+      })
+    })
   })
 })


### PR DESCRIPTION
/cc @zendesk/rules @jsdnxx 

### Description

Every status set request subscribes to a resource before sending the changes to redis.

Because the server would keep subscribed even if no client was interested, sending set requests (same resource) to different servers caused a message explosion, as all of them would be listening for those messages.

Tested locally, seems to behave as expected, unsubscribes only if resource.subscribers is empty.

@jsdnxx if you have some time would appreciate reviewing the pr, @vanchi-zendesk will be out for a month =)

### Risks
* Medium.