### PR TITLE
[POC] Send userData for client_offline

### DIFF
--- a/src/core/resources/presence/index.js
+++ b/src/core/resources/presence/index.js
@@ -78,15 +78,16 @@ Presence.prototype.setup = function () {
     })
   })
 
-  this.manager.on('client_offline', function (clientSessionId, userId, explicit) {
-    logging.info('#presence - client_offline', clientSessionId, userId, explicit, self.to)
+  this.manager.on('client_offline', function (clientSessionId, userId, explicit, userData) {
+    logging.info('#presence - client_offline', clientSessionId, userId, explicit, userData, self.to)
     self.broadcast({
       to: self.to,
       op: 'client_offline',
       explicit: !!explicit,
       value: {
         userId: userId,
-        clientId: clientSessionId
+        clientId: clientSessionId,
+        userData: userData
       }
     }, clientSessionId)
   })


### PR DESCRIPTION
This is PoC, don't merge.

### Problem
[Sense](https://github.com/zendesk/sense) consumes `radar.resources` kafka topic to store agents presence on its side. Radar doesn't store account ID at the moment, and this is a problem from Sense point of view, where everything is keyed by account ID. One way to solve it is to add account ID to [`userData`](https://github.com/zendesk/zendesk/blob/master/app/helpers/radar_helper.rb#L28-L31).  `userData` is then passed around and send to the kafka topic, but not for every operations, e.g. `client_offline` doesn't attach `userData`. 