### PR TITLE
Remove support for node v0.1x / Emit profiling once on sentry down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- '0.10'
 - '4.2'
 services:
 - redis-server

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
-### 0.21.9
-* [PR #243](https://github.com/zendesk/radar/pull/243) - Emit profiling once on sentry down
+### 0.30.0
+* [PR #243](https://github.com/zendesk/radar/pull/243) - Remove support for node v0.1x / Emit profiling once on sentry down
 
 ### 0.21.8
 * [PR #236](https://github.com/zendesk/radar/pull/236) - Api status set: unsubscribe if list of subscribers is empty

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+### 0.21.9
+* [PR #243](https://github.com/zendesk/radar/pull/243) - Emit profiling once on sentry down
+
 ### 0.21.8
 * [PR #236](https://github.com/zendesk/radar/pull/236) - Api status set: unsubscribe if list of subscribers is empty
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "radar",
   "description": "Realtime apps with a high level API based on engine.io",
-  "version": "0.21.8",
+  "version": "0.30.0",
   "author": "Zendesk, Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": "0.10 - 5"
+    "node": ">=4"
   },
   "contributors": [
     "Mikito Takada <mikito.takada@gmail.com>",

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ See [radar.zendesk.com](http://radar.zendesk.com) for detailed documentation.
 This is the project necessary for running a radar server. Documentation about building an app and using the client-side libraries is available at [radar.zendesk.com](http://radar.zendesk.com). Browse [radar client libraries and tools](https://github.com/zendesk?utf8=%E2%9C%93&query=radar).
 
 ## Installation
-Requires: redis 2.8+, node.js 0.10+
+Requires: redis 2.8+, node.js 4+
 
 ###Installing from npm:
 


### PR DESCRIPTION
Currently `profiling` is emitted (at least) for each presence resource existing in the server when a sentry goes down. Even if a given presence resource has no session for the sentryId. It's causing `profiling` to run several times per millisecond.

This PR changes this behaviour to emit `profiling` once when a sentry goes down.

Also `shelljs` dependency on `simple_sentinel` is crashing when running on node v0.10. This PR removes support for node v0.10, requiring node version >=4.