### PR TITLE
Remove "Zendesk is hiring Radar developers", as we don't currently have any such jobs posted.

### DIFF
--- a/client.html
+++ b/client.html
@@ -41,10 +41,6 @@
         <h5>Full source code on Github</h5>
       </a>
 
-      <a href="http://www.zendesk.com/company/careers?jvi=oHiWWfwB,Job" target="_blank">
-        <h5>Zendesk is hiring Radar developers</h5>
-      </a>
-
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -41,10 +41,6 @@
         <h5>Full source code on Github</h5>
       </a>
 
-      <a href="http://www.zendesk.com/company/careers?jvi=oHiWWfwB,Job" target="_blank">
-        <h5>Zendesk is hiring Radar developers</h5>
-      </a>
-
     </div>
   </div>
 

--- a/layout/page.html
+++ b/layout/page.html
@@ -41,10 +41,6 @@
         <h5>Full source code on Github</h5>
       </a>
 
-      <a href="http://www.zendesk.com/company/careers?jvi=oHiWWfwB,Job" target="_blank">
-        <h5>Zendesk is hiring Radar developers</h5>
-      </a>
-
     </div>
   </div>
 

--- a/rest.html
+++ b/rest.html
@@ -41,10 +41,6 @@
         <h5>Full source code on Github</h5>
       </a>
 
-      <a href="http://www.zendesk.com/company/careers?jvi=oHiWWfwB,Job" target="_blank">
-        <h5>Zendesk is hiring Radar developers</h5>
-      </a>
-
     </div>
   </div>
 

--- a/server.html
+++ b/server.html
@@ -41,10 +41,6 @@
         <h5>Full source code on Github</h5>
       </a>
 
-      <a href="http://www.zendesk.com/company/careers?jvi=oHiWWfwB,Job" target="_blank">
-        <h5>Zendesk is hiring Radar developers</h5>
-      </a>
-
     </div>
   </div>
 


### PR DESCRIPTION
Pages on http://radar.zendesk.com/ have a link "Zendesk is hiring Radar developers", but the link is broken and goes to a blank page on the Zendesk site. We're almost always hiring :) but we don't have any specific jobs posted for Radar at this time, and the link doesn't go to our jobs page, so the link is just confusing.

The website http://radar.zendesk.com/ is published using GitHub Pages. It is sourced from the `gh-pages` branch of the Radar GitHub repo.

/cc @smedberg 