### PR TITLE
Fixes issue where the state machine infinitely disconnects when starting in a bad state.

### DIFF
--- a/src/core/resources/presence/index.js
+++ b/src/core/resources/presence/index.js
@@ -164,7 +164,7 @@ Presence.prototype.sync = function (clientSession, message) {
   this.fullRead(function (online) {
     if (message.options && parseInt(message.options.version, 10) === 2) {
       var value = self.manager.getClientsOnline()
-      logging.info('#presence - sync', value)
+      logging.info('#presence - sync', self.to, clientSession.id, value)
       clientSession.send({
         op: 'get',
         to: self.to,
@@ -194,7 +194,7 @@ Presence.prototype.get = function (clientSession, message) {
     if (message.options && message.options.version === 2) {
       // pob
       value = self.manager.getClientsOnline()
-      logging.info('#presence - get', value)
+      logging.info('#presence - get', self.to, clientSession.id, value)
     } else {
       value = online
     }

--- a/test/client.reconnect.test.js
+++ b/test/client.reconnect.test.js
@@ -62,15 +62,21 @@ describe('When radar server restarts', function () {
     var clientEvents = []
     var client2Events = []
 
-    var states = ['disconnected', 'connected', 'ready']
-    states.forEach(function (state) {
-      client.once(state, function () { clientEvents.push(state) })
-      client2.once(state, function () { client2Events.push(state) })
+    var states = ['connected', 'activated']
+    client.once('disconnected', function () {
+      states.forEach(function (state) {
+        client.once(state, function () { clientEvents.push(state) })
+      })
+    })
+    client2.once('disconnected', function () {
+      states.forEach(function (state) {
+        client2.once(state, function () { client2Events.push(state) })
+      })
     })
 
     common.restartRadar(radar, common.configuration, [client, client2], function () {
-      assert.deepEqual(clientEvents, ['disconnected', 'connected', 'ready'])
-      assert.deepEqual(client2Events, ['disconnected', 'connected', 'ready'])
+      assert.deepEqual(clientEvents, ['connected', 'activated'])
+      assert.deepEqual(client2Events, ['connected', 'activated'])
       assert.equal('activated', client.currentState())
       assert.equal('activated', client2.currentState())
       done()


### PR DESCRIPTION
Fix test for https://github.com/zendesk/radar_client/pull/81.

https://github.com/zendesk/radar_client/pull/81 introduces an asynchronous `enterState` event. Which `test/client.reconnect.test.js` relies on synchronously. This PR waits for the `disconnected` event before listening for the `connected` and `activated` (which is also asynchronous instead of `ready`) events.