### PR TITLE
serialize-javascript bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5403,7 +5403,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -5734,10 +5733,12 @@
       "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
     },
     "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-      "dev": true
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -6669,6 +6670,12 @@
         "worker-farm": "^1.7.0"
       },
       "dependencies": {
+        "serialize-javascript": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+          "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "persistence": "^2.0.1",
     "radar_message": "^1.3.1",
     "semver": "^7.1.3",
+    "serialize-javascript": ">=3.1.0",
     "uuid": "^7.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description
<p>serialize-javascript prior to 3.1.0 allows remote attackers to inject arbitrary code via the function "deleteFunctions" within "index.js".</p>
<p>An object such as <code>{"foo": /1"/, "bar": "a\"@__R-&lt;UID&gt;-0__@"}</code> was serialized as <code>{"foo": /1"/, "bar": "a\/1"/}</code>, which allows an attacker to escape the <code>bar</code> key. This requires the attacker to control the values of both <code>foo</code> and <code>bar</code> and guess the value of <code>&lt;UID&gt;</code>. The UID has a keyspace of approximately 4 billion making it a realistic network attack.</p>
<p>The following proof-of-concept calls <code>console.log()</code> when the running <code>eval()</code>:<br>
<code>eval('('+ serialize({"foo": /1" + console.log(1)/i, "bar": '"@__R-&lt;UID&gt;-0__@'}) + ')');</code></p>
