### PR TITLE
Update ioredis to v5.9.3 for Valkey v8.2 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "minilog": "^2.1.0",
         "mobx": "^6.10.2",
         "nonblocking": "^1.0.3",
-        "persistence": "^2.1.0",
+        "persistence": "^2.3.0",
         "radar_message": "^1.4.0",
         "semver": "^7.5.4",
         "uuid": "^8.3.2"
@@ -167,9 +167,9 @@
       }
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
+      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
@@ -1076,9 +1076,9 @@
       }
     },
     "node_modules/denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
@@ -2767,25 +2767,23 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.30.0.tgz",
-      "integrity": "sha512-P9F4Eo6zicYsIJbEy/mPJmSxKY0rVcmiy5H8oXPxPDotQRCvCBjBuI5QWoQQanVE9jdeocnum5iqYAHl4pHdLA==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.3.tgz",
+      "integrity": "sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==",
       "license": "MIT",
       "dependencies": {
-        "@ioredis/commands": "^1.0.2",
+        "@ioredis/commands": "1.5.0",
         "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.1",
-        "denque": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
         "lodash.defaults": "^4.2.0",
-        "lodash.flatten": "^4.4.0",
         "lodash.isarguments": "^3.1.0",
-        "p-map": "^2.1.0",
         "redis-errors": "^1.2.0",
         "redis-parser": "^3.0.0",
         "standard-as-callback": "^2.1.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12.22.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3405,12 +3403,6 @@
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "license": "MIT"
     },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-      "license": "MIT"
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -3979,15 +3971,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -4117,12 +4100,11 @@
       }
     },
     "node_modules/persistence": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/persistence/-/persistence-2.2.1.tgz",
-      "integrity": "sha512-R2lbMILBDcDHl5zshxItbJAbbHqp02FABe27fDiyGp3UNqIBhy9bVluPtWKjvAZcHlfP/8ny9nSA08sv+Va8QA==",
+      "version": "2.3.0",
+      "resolved": "git+ssh://git@github.com/zendesk/persistence.git#311472f9d6ff425e97ba41dff5e8503ff3d78ce0",
       "license": "MIT",
       "dependencies": {
-        "ioredis": "^4.28.5"
+        "ioredis": "^5.0.0"
       }
     },
     "node_modules/picocolors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "radar",
-      "version": "0.43.1",
+      "version": "0.44.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@gerhobbelt/nomnom": "^1.8.4-31",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "minilog": "^2.1.0",
     "mobx": "^6.10.2",
     "nonblocking": "^1.0.3",
-    "persistence": "^2.1.0",
+    "persistence": "^2.3.0",
     "radar_message": "^1.4.0",
     "semver": "^7.5.4",
     "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "radar",
   "description": "Realtime apps with a high level API based on engine.io",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "author": "Zendesk, Inc.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### Description

Updating the version of `ioredis` to a version compatible with Valkey.

### References

* Jira: [COMPASS-3927](https://zendesk.atlassian.net/browse/COMPASS-3927)

### Risks

* Medium: Updates the version of the library used to connect to redis. Undocumented breaking changes in the API could result in errors once deployed, and we should see them on startup.
* Rollback: Revert this PR and redeploy


[COMPASS-3927]: https://zendesk.atlassian.net/browse/COMPASS-3927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ