### PR TITLE
updates persistence and audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "radar",
-      "version": "0.44.1",
+      "version": "0.44.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@gerhobbelt/nomnom": "^1.8.4-31",
@@ -22,7 +22,7 @@
         "minilog": "^2.1.0",
         "mobx": "^6.10.2",
         "nonblocking": "^1.0.3",
-        "persistence": "^2.3.0",
+        "persistence": "^2.3.1",
         "radar_message": "^1.4.0",
         "semver": "^7.5.4",
         "uuid": "^8.3.2"
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1998,9 +1998,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3092,9 +3092,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -3780,8 +3780,9 @@
       }
     },
     "node_modules/persistence": {
-      "version": "2.3.0",
-      "resolved": "git+ssh://git@github.com/zendesk/persistence.git#311472f9d6ff425e97ba41dff5e8503ff3d78ce0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/persistence/-/persistence-2.3.1.tgz",
+      "integrity": "sha512-/tOh47PPbh5iEfBKzHGvbK+UNRy26W9INRHYsBiUOyPRWtD966KgVwdSd0V9YvKmckTIdZpjKkwcWHdJ/zwVRQ==",
       "license": "MIT",
       "dependencies": {
         "ioredis": "^5.0.0"
@@ -4499,9 +4500,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "radar",
   "description": "Realtime apps with a high level API based on engine.io",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "author": "Zendesk, Inc.",
   "license": "Apache-2.0",
   "engines": {
@@ -54,7 +54,7 @@
     "minilog": "^2.1.0",
     "mobx": "^6.10.2",
     "nonblocking": "^1.0.3",
-    "persistence": "^2.3.0",
+    "persistence": "^2.3.1",
     "radar_message": "^1.4.0",
     "semver": "^7.5.4",
     "uuid": "^8.3.2"


### PR DESCRIPTION
### Description

upgrades `persistence` to `2.3.1`, and runs `npm audit fix` to resolve some transient vulns

### References

* Github issue:

### Risks

* Low : Minor package updates
* Rollback: revert
