### PR TITLE
Fix uuid security vulnerability (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "persistence": "^2.3.1",
         "radar_message": "^1.4.0",
         "semver": "^7.5.4",
-        "uuid": "^8.3.2"
+        "uuid": "^14.0.0"
       },
       "bin": {
         "radar": "bin/server.js"
@@ -5366,12 +5366,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "persistence": "^2.3.1",
     "radar_message": "^1.4.0",
     "semver": "^7.5.4",
-    "uuid": "^8.3.2"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "chai": "^4.3.8",


### PR DESCRIPTION
### Description

Upgrade `uuid` from ^8.3.2 to 14.0.0 to fix a moderate severity security vulnerability.

The vulnerability ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)) involves a missing buffer bounds check in v3/v5/v6 when a `buf` parameter is provided.

This codebase only uses `uuid.v4()` which is unaffected, but upgrading removes the vulnerability from the dependency tree.

### References

* Github issue: https://github.com/advisories/GHSA-w5hq-g745-h8pq

### Risks

* Low: This is a major version bump, but the breaking changes don't affect our usage (we only use `v4()`). All tests pass.
* Rollback: Revert this commit

🤖 Generated with [Claude Code](https://claude.ai/code)