### PR TITLE
[COMPASS-4333] fix: upgrade dependencies to resolve 5 security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "radar",
-      "version": "0.44.2",
+      "version": "0.44.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@gerhobbelt/nomnom": "^1.8.4-31",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "persistence": "^2.3.1",
         "radar_message": "^1.4.0",
         "semver": "^7.5.4",
-        "uuid": "^8.3.2"
+        "uuid": "^11.1.1"
       },
       "bin": {
         "radar": "bin/server.js"
@@ -1888,9 +1888,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true,
       "funding": [
         {
@@ -5366,12 +5366,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -5534,9 +5538,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "radar",
   "description": "Realtime apps with a high level API based on engine.io",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "author": "Zendesk, Inc.",
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "persistence": "^2.3.1",
     "radar_message": "^1.4.0",
     "semver": "^7.5.4",
-    "uuid": "^8.3.2"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "chai": "^4.3.8",
@@ -103,6 +103,8 @@
     "diff": "^8.0.3",
     "minimatch": "^10.2.3",
     "glob": "^13.0.6",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "fast-uri": "^3.1.2",
+    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
### Description

Fixes 5 Dependabot security vulnerabilities (2 out of SLA, 2 HIGH) by upgrading vulnerable packages:
- uuid: upgraded from 8.3.2 to 11.1.1 (MEDIUM)
- fast-uri: 3.1.2 via overrides (HIGH, out of SLA)
- ws: 8.21.0 via overrides (MEDIUM)

### References

* Jira: https://zendesk.atlassian.net/browse/COMPASS-4333

### Tests
* Core functionality tests pass

### Risks

* **Low**: Dependency security updates. Pre-existing test flakiness documented.

### Rollback:

* Revert PR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)