### PR TITLE
chore: OBS-000 reduce wasteful log emission in radar

### DIFF
--- a/src/core/resources/presence/index.js
+++ b/src/core/resources/presence/index.js
@@ -153,7 +153,7 @@ Presence.prototype.subscribe = function (clientSession, message) {
 }
 
 Presence.prototype.unsubscribe = function (clientSession, message) {
-  logging.info('#presence - implicit disconnect', clientSession.id, this.to)
+  logging.debug('#presence - implicit disconnect', clientSession.id, this.to)
   this.manager.disconnectClient(clientSession.id)
 
   Resource.prototype.unsubscribe.call(this, clientSession, message)

--- a/src/core/resources/presence/index.js
+++ b/src/core/resources/presence/index.js
@@ -51,7 +51,7 @@ Presence.prototype.setup = function () {
   })
 
   this.manager.on('client_online', function (clientSessionId, userId, userType, userData, clientData) {
-    logging.info('#presence - client_online', clientSessionId, userId, self.to, userData, clientData)
+    logging.debug('#presence - client_online', clientSessionId, self.to)
     self.broadcast({
       to: self.to,
       op: 'client_online',

--- a/src/core/resources/presence/index.js
+++ b/src/core/resources/presence/index.js
@@ -79,7 +79,7 @@ Presence.prototype.setup = function () {
   })
 
   this.manager.on('client_offline', function (clientSessionId, userId, explicit) {
-    logging.info('#presence - client_offline', clientSessionId, userId, explicit, self.to)
+    logging.debug('#presence - client_offline', clientSessionId, self.to)
     self.broadcast({
       to: self.to,
       op: 'client_offline',


### PR DESCRIPTION
Reduce wasteful log emission in `radar` by demoting three per-connection `radar:presence` INFO logs to DEBUG, which account for ~99.6% of the service's log volume and bury the ERROR signal.

## Fixed patterns

### W4 — `client_online` per-connection INFO (`src/core/resources/presence/index.js:53-54`)
Demoted `logging.info('#presence - client_online', ...)` to `logging.debug` and dropped the whole-object `userData`/`clientData` args (Tier-2 identifier exposure). Fired one INFO per client connection: ~62.9M events/7d, ~47% of service log volume.

### W4 — `client_offline` per-connection INFO (`src/core/resources/presence/index.js:81-82`)
Demoted to `logging.debug`. Fired one INFO per client disconnect: ~32.4M events/7d, ~24% of service log volume.

### W4 — implicit-disconnect per-connection INFO (`src/core/resources/presence/index.js:155-156`)
Demoted to `logging.debug`. Fired one INFO per dropped client session (`unsubscribe`): ~38.9M events/7d, ~29% of service log volume.

Fixes follow the finding's primary recommendation (demote to DEBUG). The StatsD-counter alternative was not taken because `statsd` is not wired into this module; a counter can be added as a follow-up.

## Modeled savings
- Estimated monthly waste: **~$476/mo**
- Immediate savings: **~$343/mo**

## Skipped findings
None skipped. All three Confirmed findings matched current code and were fixed. There were no Likely findings. Unverifiable findings (W8, W11 whole-object logging, `console.log` sites) were out of scope for this Confirmed/Likely remediation pass; the W11 PII exposure on `client_online` was incidentally removed as part of the demotion above.

Savings are modeled from a trailing-7d Datadog pull, not committed — validate before booking.

## Risks
low — logging-only changes to routine high-volume emissions; WARN/ERROR paths, APM coverage, and application behavior are unchanged.

## Breaking changes
no — no public API or runtime behavior changes.
---
## Cloud cost sprint tracking

Jira: [COMPASS-4385](https://zendesk.atlassian.net/browse/COMPASS-4385)
Potential savings: $343/month (modeled estimate)

This PR is part of the cloud spend reduction sprint running July 19–August 1, 2026. The change was generated in bulk with AI assistance and requires appropriate engineering scrutiny before merge. Review the implementation for correctness, unintended side effects, and opportunities to apply the cost-reduction technique more broadly. The PR may be merged as-is or refactored to better support the overall cost-reduction goals.

For questions or concerns, contact `#ask-sre`.


[COMPASS-4385]: https://zendesk.atlassian.net/browse/COMPASS-4385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ