### PR TITLE
Bump fast-uri to resolve security alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1915,9 +1915,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -2979,9 +2979,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -103,9 +103,9 @@
     "diff": "^8.0.3",
     "minimatch": "^10.2.3",
     "glob": "^13.0.6",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "fast-uri": "^3.1.5",
     "ws": "^8.21.0",
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "minimatch": "^10.2.3",
     "glob": "^13.0.6",
     "js-yaml": "^4.3.0",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.5",
     "ws": "^8.21.0",
     "brace-expansion": "^5.0.8"
   }


### PR DESCRIPTION
cc: @zendesk/compass 
### Description

Bumps 
- `fast-uri` 3.1.4 -> 3.1.5 
- `js-yaml` 4.3.0 -> 4.3.1
- `brace-expansion` 5.0.8 -> 5.0.9


### References

* Jira: [COMPASS-4447](https://zendesk.atlassian.net/browse/COMPASS-4447)
* Dependabot alert: https://github.com/zendesk/radar/security/dependabot/72

### Risks

* Low: only patch/minor version bumps.
* Rollback: revert this commit 

[COMPASS-4447]: https://zendesk.atlassian.net/browse/COMPASS-4447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ